### PR TITLE
#62 Added Include/Exclude tests from the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,24 @@ After defining some NBench `PerfBenchmark` methods and declaring some measuremen
 PS> Install-Package NBench.Runner
 PS> .\packages\NBench.Runner\NBench.Runner.exe .\src\bin\Debug\MyPerfTests.dll output-directory="C:\Perf"
 ```
-
 And this command will run your `PerfBenchmark` and write output [that looks like this](https://gist.github.com/Aaronontheweb/8e0bfa2cccc63f5bd8bf) to a markdown file in the `output-directory`.
+
+## Command Line Paramters
+```
+NBench.Runner.exe [assembly names] [output-directory={dir-path}] [configuration={file-path}] [include=MyTest*.Perf*,Other*Spec] [exclude=*Long*]
+```
+
+* **assembly names** - list of assemblies to load and test. Space delimited. Requires `.dll` or `.exe` at the end of each assembly name
+* **output-directory=path** - folder where a Markdown report will be exported. Report will [look like this](https://gist.github.com/Aaronontheweb/8e0bfa2cccc63f5bd8bf)
+* **configuration=path** - folder with a config file to be used when loading the `assembly names`
+* **include=name test pattern** - a "`,`"(comma) separted list of wildcard pattern to be mached and included in the tests. Default value is `*` (all)
+The test is executed on the complete name of the benchmark `Namespace.Class+MethodName`
+* **exclude=name test pattern** - a "`,`"(comma) separted list of wildcard pattern to be mached and excluded in the tests. Default value is `` (none)
+The test is executed on the complete name of the benchmark `Namespace.Class+MethodName`
+
+Supported wildcard patterns are `*` any string and `?` any char. In order to include a class with all its tests in the benchmark
+you need to specify a pattern finishing in `*`. E.g. `include=*.MyBenchmarkClass.*`.
+
 
 ## API
 Every NBench performance test is created by decorating a method on a POCO class with a `PerfBenchmark` attribute and at least one type of "measurement" attribute.

--- a/src/NBench.Runner/Program.cs
+++ b/src/NBench.Runner/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -17,13 +18,20 @@ namespace NBench.Runner
 		/// <summary>
 		/// NBench Runner takes the following <see cref="args"/>
 		/// 
-		/// C:\> NBench.Runner.exe [assembly name] [output-directory={dir-path}] [configuration={file-path}]
+		/// C:\> NBench.Runner.exe [assembly name] [output-directory={dir-path}] [configuration={file-path}] [include=MyTest*.Perf*,Other*Spec] [exclude=*Long*]
 		/// 
 		/// </summary>
 		/// <param name="args">The commandline arguments</param>
 		static int Main(string[] args)
-        { 
-            TestPackage package = new TestPackage(CommandLine.GetFiles(args));
+		{
+			string[] include = null;
+			string[] exclude = null;
+			if (CommandLine.HasProperty("include"))
+				include = CommandLine.GetProperty("include").Split(',');
+			if (CommandLine.HasProperty("exclude"))
+				include = CommandLine.GetProperty("exclude").Split(',');
+
+			TestPackage package = new TestPackage(CommandLine.GetFiles(args), include, exclude);
 
 			if (CommandLine.HasProperty("output-directory"))
 				package.OutputDirectory = CommandLine.GetProperty("output-directory");
@@ -33,9 +41,9 @@ namespace NBench.Runner
 
 			package.Validate();
 
-            bool allTestsPassed = TestRunner.Run(package);
+            var result = TestRunner.Run(package);
        
-            return allTestsPassed ? 0 : -1;
+            return result.AllTestsPassed ? 0 : -1;
         }
     }
 }

--- a/src/NBench/Sdk/TestPackage.cs
+++ b/src/NBench/Sdk/TestPackage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace NBench.Sdk
@@ -13,12 +14,28 @@ namespace NBench.Sdk
     [Serializable]
     public class TestPackage : MarshalByRefObject
     {
+		/// <summary>
+		/// List of assemblies to be loaded and tested
+		/// </summary>
         private List<string> _testfiles = new List<string>();
-        
-        /// <summary>
-        /// Gets or sets a file path to the configuration file (app.config) used for the test assemblies
-        /// </summary>
-        public string ConfigurationFile { get; set; }
+
+		/// <summary>
+		/// List of patterns to be included in the tests. Wildchars supported (*, ?)
+		/// </summary>
+		private List<string> _include = new List<string>();
+		private List<Regex> _includePatterns;	// locally build cache
+
+		/// <summary>
+		/// List of patterns to be excluded from the tests. Wildchars supported (*, ?)
+		/// </summary>
+		private List<string> _exclude = new List<string>();
+		private List<Regex> _excludePatterns;   // locally build cache
+
+
+		/// <summary>
+		/// Gets or sets a file path to the configuration file (app.config) used for the test assemblies
+		/// </summary>
+		public string ConfigurationFile { get; set; }
 
         /// <summary>
         /// Gets or sets the directory for the result output file
@@ -38,23 +55,38 @@ namespace NBench.Sdk
             get { return _testfiles; }
         }
 
-        /// <summary>
-        /// Initializes a new test package with one test file.
-        /// </summary>
-        /// <param name="filePath">The path to a test file.</param>
-        public TestPackage(string filePath)
+	    /// <summary>
+	    /// Initializes a new test package with one test file.
+	    /// </summary>
+	    /// <param name="filePath">The path to a test file.</param>
+	    /// <param name="include">An optional include pattern</param>
+	    /// <param name="exclude">An optiona exclude pattern</param>
+	    public TestPackage(string filePath, IEnumerable<string> include = null, IEnumerable<string> exclude = null)
 		{
 			if (string.IsNullOrEmpty(filePath))
 				throw new ArgumentNullException("filePath");
 
 			AddSingleFile(filePath);
-		}		
 
-		/// <summary>
-		/// Initializes a new package with multiple test files.
-		/// </summary>
-		/// <param name="files">A list of test files.</param>
-		public TestPackage(IEnumerable<string> files)
+			if (include != null)
+			{
+				foreach (var p in include)
+					AddInclude(p.Trim());
+			}
+			if (exclude != null)
+			{
+				foreach (var p in exclude)
+					AddExclude(p.Trim());
+			}
+		}
+
+	    /// <summary>
+	    /// Initializes a new package with multiple test files.
+	    /// </summary>
+	    /// <param name="files">A list of test files.</param>
+	    /// <param name="include">Optional list of include patterns</param>
+	    /// <param name="exclude">Optional list of exclude patterns</param>
+	    public TestPackage(IEnumerable<string> files, IEnumerable<string> include = null, IEnumerable<string> exclude = null)
         {
             if (files == null || !files.Any())
                 throw new ArgumentException("Please provide at least one test file." ,"files");
@@ -67,7 +99,18 @@ namespace NBench.Sdk
 				foreach (var file in files)
 					_testfiles.Add(Path.GetFullPath(file));
 			}
-        }
+
+		    if (include != null)
+		    {
+			    foreach(var p in include)
+					AddInclude(p.Trim());
+		    }
+			if (exclude != null)
+			{
+				foreach (var p in exclude)
+					AddExclude(p.Trim());
+			}
+		}
 
         /// <summary>
         /// Validates the test package
@@ -126,5 +169,60 @@ namespace NBench.Sdk
 
 			Name = Path.GetFileNameWithoutExtension(filePath);
 		}
-	}	
+
+		/// <summary>
+		/// Add a pattern to be excluded. We'll ignore nulls.
+		/// </summary>
+		/// <param name="exclude"></param>
+		private void AddExclude(string exclude)
+		{
+			if (String.IsNullOrEmpty(exclude))
+				return;
+			
+			_exclude.Add(exclude);
+		}
+
+		/// <summary>
+		/// Add a pattern to be included. We'll ignore nulls.
+		/// </summary>
+		/// <param name="include"></param>
+		private void AddInclude(string include)
+		{
+			if (String.IsNullOrEmpty(include))
+				return;
+			_include.Add(include);
+		}
+
+	    public bool ShouldRunBenchmark(string benchmarkName)
+	    {
+		    PreparePatterns();
+		    return _includePatterns.All(p => p.IsMatch(benchmarkName)) && !_excludePatterns.Any(p => p.IsMatch(benchmarkName));
+	    }
+
+	    private void PreparePatterns()
+	    {
+		    if (_includePatterns != null)
+			    return;
+			_includePatterns = new List<Regex>();
+		    if (_include.Count == 0)
+		    {
+			    // no pattern - assume pattern is "*"
+			    _includePatterns.Add(BuildPattern("*"));
+		    }
+		    else
+		    {
+			    _include.ForEach(p => _includePatterns.Add(BuildPattern(p)));
+		    }
+			_excludePatterns = new List<Regex>();
+		    _exclude.ForEach(p => _excludePatterns.Add(BuildPattern(p)));
+	    }
+
+		/// <summary>
+		/// Converts a wildcard to a regex pattern
+		/// </summary>
+		public static Regex BuildPattern(string pattern)
+		{
+			return new Regex("^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		}
+	}
 }

--- a/src/NBench/Sdk/TestRunner.cs
+++ b/src/NBench/Sdk/TestRunner.cs
@@ -2,22 +2,29 @@
 using NBench.Reporting.Targets;
 using NBench.Sdk.Compiler;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace NBench.Sdk
 {
+	/// <summary>
+	/// Results collected by the test runner
+	/// </summary>
+	[Serializable]
+	public class TestRunnerResult
+	{
+		public bool AllTestsPassed { get; set; }
+
+		public int ExecutedTestsCount { get; set; }
+		public int IgnoredTestsCount { get; set; }
+	}
     /// <summary>
     /// Executor of tests
     /// </summary>
     /// <remarks>Will be created in separated appDomain therefor it have to be marshaled.</remarks>
     public class TestRunner : MarshalByRefObject
     {
-        private TestPackage _package;
+        private readonly TestPackage _package;
 
         /// <summary>
         /// Initializes a new instance of the test runner.
@@ -46,7 +53,7 @@ namespace NBench.Sdk
         /// <param name="package">The test package to execute.</param>
         /// <returns>True if all tests passed.</returns>
         /// <remarks>Creates a new AppDomain and executes the tests.</remarks>
-        public static bool Run(TestPackage package)
+        public static TestRunnerResult Run(TestPackage package)
         {
             // create the test app domain
             var testDomain = DomainManager.CreateDomain(package);
@@ -84,17 +91,20 @@ namespace NBench.Sdk
         /// Executes the tests
         /// </summary>
         /// <returns>True if all tests passed.</returns>
-        public bool Execute()
+        public TestRunnerResult Execute()
         {
             SetProcessPriority();
 
             IBenchmarkOutput output = CreateOutput();
             var discovery = new ReflectionDiscovery(output);
-            bool allTestsPassed = true;
+	        var result = new TestRunnerResult()
+	        {
+		        AllTestsPassed = true
+	        };
 
 			try
 			{
-				foreach (var testFile in _package.Files)
+                foreach (var testFile in _package.Files)
 				{
 					var assembly = AssemblyRuntimeLoader.LoadAssembly(testFile);
 
@@ -102,22 +112,32 @@ namespace NBench.Sdk
 
 					foreach (var benchmark in benchmarks)
 					{
-						output.WriteLine($"------------ STARTING {benchmark.BenchmarkName} ---------- ");
-						benchmark.Run();
-						benchmark.Finish();
+						// verify if the benchmark should be included/excluded from the list of benchmarks to be run
+						if (_package.ShouldRunBenchmark(benchmark.BenchmarkName))
+						{
+							output.WriteLine($"------------ STARTING {benchmark.BenchmarkName} ---------- ");
+							benchmark.Run();
+							benchmark.Finish();
 
-						// if one assert fails, all fail
-						allTestsPassed = allTestsPassed && benchmark.AllAssertsPassed;
-						output.WriteLine($"------------ FINISHED {benchmark.BenchmarkName} ---------- ");
+							// if one assert fails, all fail
+							result.AllTestsPassed = result.AllTestsPassed && benchmark.AllAssertsPassed;
+							output.WriteLine($"------------ FINISHED {benchmark.BenchmarkName} ---------- ");
+							result.ExecutedTestsCount = result.ExecutedTestsCount+1;
+						}
+						else
+						{
+							output.WriteLine($"------------ NOTRUN {benchmark.BenchmarkName} ---------- ");
+							result.IgnoredTestsCount = result.IgnoredTestsCount+1;
+						}
 					}
 				}
 			} catch(Exception ex)
 			{
 				output.Error(ex, "Error while executing the tests.");
-				allTestsPassed = false;
+				result.AllTestsPassed = false;
 			}
 
-            return allTestsPassed;
+            return result;
         }
 
         /// <summary>

--- a/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
+++ b/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using NBench.Reporting;
 using NBench.Reporting.Targets;
@@ -39,16 +40,57 @@ namespace NBench.Tests.End2End
         [Fact]
         public void LoadAssemblyCorrect()
         {
+	        var package = LoadPackage();
+	        var result = TestRunner.Run(package);
+            Assert.True(result.AllTestsPassed);
+			Assert.NotEqual(0, result.ExecutedTestsCount);
+			Assert.Equal(0, result.IgnoredTestsCount);
+		}
+
+		
+	    [Fact]
+		public void RunnerIncludeInvalidName()
+		{
+			var package = LoadPackage(new string[] { "unknown" });
+
+			var result = TestRunner.Run(package);
+			Assert.True(result.AllTestsPassed);
+			Assert.Equal(0, result.ExecutedTestsCount);
+			Assert.NotEqual(0, result.IgnoredTestsCount);
+		}
+
+		[Fact]
+		public void RunnerIncludePattern()
+		{
+			var package = LoadPackage(new [] { "*.ConfigBenchmark*" });
+
+			var result = TestRunner.Run(package);
+			Assert.True(result.AllTestsPassed);
+			Assert.Equal(1, result.ExecutedTestsCount);
+			Assert.NotEqual(0, result.IgnoredTestsCount);
+		}
+		[Fact]
+		public void RunnerExcludePattern()
+		{
+			var package = LoadPackage(null, new [] { "*CounterThroughputBenchmark*", "*SimpleCounterBenchmark*" });
+
+			var result = TestRunner.Run(package);
+			Assert.True(result.AllTestsPassed);
+			Assert.Equal(1, result.ExecutedTestsCount);
+			Assert.NotEqual(0, result.IgnoredTestsCount);
+		}
+
+		private static TestPackage LoadPackage(IEnumerable<string> include = null, IEnumerable<string> exclude = null)
+		{
 #if DEBUG
-	var package = new TestPackage(@"..\..\..\NBench.Tests.Assembly\bin\Debug\NBench.Tests.Assembly.dll");
+	var package = new TestPackage(@"..\..\..\NBench.Tests.Assembly\bin\Debug\NBench.Tests.Assembly.dll", include, exclude);
 #else
-    var package = new TestPackage(@"..\..\..\NBench.Tests.Assembly\bin\Release\NBench.Tests.Assembly.dll"); 
+			var package = new TestPackage(@"..\..\..\NBench.Tests.Assembly\bin\Release\NBench.Tests.Assembly.dll", include, exclude);
 #endif
 
 			package.Validate();
-
-			Assert.True(TestRunner.Run(package));
-        }
-    }
+			return package;
+		}
+	}
 }
 


### PR DESCRIPTION
New CSV list of patterns to include and/or exclude specific tests from the benchmark
NBench.Runner.exe [assembly names] [output-directory={dir-path}] [configuration={file-path}] [include=MyTest*.Perf*,Other*Spec] [exclude=*Long*]