### PR TITLE
changed ReflectionDiscovery to respect Skip property on PerfBenchmark attribute

### DIFF
--- a/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
+++ b/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
@@ -192,6 +192,10 @@ namespace NBench.Sdk.Compiler
         {
             var hasPerformanceBenchmarkAttribute = x.IsDefined(PerformanceBenchmarkAttributeType, true);
             var hasAtLeastOneMeasurementAttribute = x.IsDefined(MeasurementAttributeType, true);
+            var skipReason = (x.GetCustomAttribute(PerformanceBenchmarkAttributeType) as
+                                                        PerfBenchmarkAttribute)?.Skip;
+            var benchmarkIsSkipped = hasPerformanceBenchmarkAttribute &&
+                                    !string.IsNullOrEmpty(skipReason);
 
             // code below is for adding interface support
             //var bla =
@@ -211,8 +215,12 @@ namespace NBench.Sdk.Compiler
             {
                 _reflectionOutput.Warning($"{x.DeclaringType?.Name}+{x.Name} has a declared PerformanceBenchmarkAttribute but no declared measurements. Skipping...");
             }
+            else if (benchmarkIsSkipped)
+            {
+                _reflectionOutput.WriteLine($"Skipping {x.DeclaringType?.Name}+{x.Name}. Reason: {skipReason}.");
+            }
 
-            return hasPerformanceBenchmarkAttribute && hasAtLeastOneMeasurementAttribute;
+            return hasPerformanceBenchmarkAttribute && hasAtLeastOneMeasurementAttribute && !benchmarkIsSkipped;
         }
 
         public static BenchmarkMethodMetadata GetSetupMethod(TypeInfo classWithBenchmarks)

--- a/tests/NBench.Tests/Sdk/Compiler/ReflectionDiscoverySpecs.cs
+++ b/tests/NBench.Tests/Sdk/Compiler/ReflectionDiscoverySpecs.cs
@@ -137,6 +137,20 @@ namespace NBench.Tests.Sdk.Compiler
             }
         }
 
+        public class BenchmarkWithOnlySkippedMethods
+        {
+            /// <summary>
+            /// Should be skipped
+            /// </summary>
+            [PerfBenchmark(TestMode = TestMode.Test, NumberOfIterations = 100, RunTimeMilliseconds = 1000, Skip = "SKIP")]
+            [CounterMeasurement("MyCounter")]
+            [CounterThroughputAssertion("MyCounter", MustBe.GreaterThan, 100.0d)]
+            public void Run()
+            {
+
+            }
+        }
+
         public static readonly TypeInfo ComplexBenchmarkTypeInfo =
             typeof (DefaultMemoryMeasurementBenchmark).GetTypeInfo();
 
@@ -144,6 +158,9 @@ namespace NBench.Tests.Sdk.Compiler
 
         public static readonly TypeInfo BenchmarkWithoutMeasurementsTypeInfo =
             typeof (BenchmarkWithoutMeasurements).GetTypeInfo();
+
+        public static readonly TypeInfo SkippedBenchmarksTypeInfo =
+            typeof (BenchmarkWithOnlySkippedMethods).GetTypeInfo();
 
         [Fact]
         public void ShouldFindSetupMethod()
@@ -221,6 +238,13 @@ namespace NBench.Tests.Sdk.Compiler
         public void ShouldNotCreateBenchmarkForClassWithNoDeclaredMeasurements()
         {
             var benchmarkMetaData = ReflectionDiscovery.CreateBenchmarksForClass(BenchmarkWithoutMeasurementsTypeInfo);
+            Assert.Equal(0, benchmarkMetaData.Count);
+        }
+
+        [Fact]
+        public void ShouldNotCreateBenchmarkForClassWithOnlySkippedBenchmarkMethods()
+        {
+            var benchmarkMetaData = ReflectionDiscovery.CreateBenchmarksForClass(SkippedBenchmarksTypeInfo);
             Assert.Equal(0, benchmarkMetaData.Count);
         }
 


### PR DESCRIPTION
Should resolve #80 - turns out `Skip` was not being honored on `PerfBenchmark` attributes. This fixes that and is verified with a spec.