### PR TITLE
added some NBench.PerformanceCounter integration tests 

### DIFF
--- a/NBench.sln
+++ b/NBench.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PerformanceCounters"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PeformanceCounters.Tests.End2End", "tests\NBench.PeformanceCounters.Tests.End2End\NBench.PeformanceCounters.Tests.End2End.csproj", "{416A4BAD-459C-4896-A44C-4C2344EBE154}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PerformanceCounters.Tests.Performance", "tests\NBench.PerformanceCounters.Tests.Performance\NBench.PerformanceCounters.Tests.Performance.csproj", "{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,5 +96,6 @@ Global
 		{E3730D65-70AE-4055-A291-800044C48FDD} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{96FCB3AB-8C76-4BD0-B97F-1239E5FF5C5C} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{416A4BAD-459C-4896-A44C-4C2344EBE154} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 	EndGlobalSection
 EndGlobal

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterRawValueCollector.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterRawValueCollector.cs
@@ -10,15 +10,17 @@ namespace NBench.PerformanceCounters.Collection
     /// <summary>
     ///     A <see cref="MetricCollector" /> implementation that uses a <see cref="PerformanceCounter" />
     ///     internally to record various system metrics.
+    /// 
+    /// Captures the RAW VALUE from performance counters.
     /// </summary>
-    public class PerformanceCounterMetricCollector : MetricCollector
+    public class PerformanceCounterRawValueCollector : MetricCollector
     {
-        private PerformanceCounter _counter;
+        protected PerformanceCounter Counter;
 
-        public PerformanceCounterMetricCollector(MetricName name, string unitName, PerformanceCounter counter,
+        public PerformanceCounterRawValueCollector(MetricName name, string unitName, PerformanceCounter counter,
             bool disposesCounter) : base(name, unitName)
         {
-            _counter = counter;
+            Counter = counter;
             DisposesCounter = disposesCounter;
         }
 
@@ -26,16 +28,16 @@ namespace NBench.PerformanceCounters.Collection
 
         public override long Collect()
         {
-            return _counter.RawValue;
+            return Counter.RawValue;
         }
 
         protected override void DisposeInternal()
         {
             if (DisposesCounter)
             {
-                _counter.Dispose();
+                Counter.Dispose();
             }
-            _counter = null;
+            Counter = null;
         }
     }
 }

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterSelector.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterSelector.cs
@@ -37,7 +37,16 @@ namespace NBench.PerformanceCounters.Collection
                 var performanceCounter = new PerformanceCounter(name.CategoryName, name.CounterName,
                     name.InstanceName ?? string.Empty, true);
 
-                return new PerformanceCounterMetricCollector(name, name.UnitName ?? MetricNames.DefaultUnitName, performanceCounter, true);
+                /*
+                 * TODO
+                 * We need to collect the correct metric from the PerformanceCounter, and that depends on the
+                 * PerformanceCounterType enumeration provided back from the PerformanceCounter object we instantiate.
+                 *
+                 * So we'll switch the implementation out based on the type of counter, with the default value being a raw value collector.
+                 */
+
+                return new PerformanceCounterRawValueCollector(name, name.UnitName ?? MetricNames.DefaultUnitName, performanceCounter, true);
+                
             }
             catch (Exception ex)
             {

--- a/src/NBench/Sdk/Compiler/ReflectionDiscovery.Configurators.cs
+++ b/src/NBench/Sdk/Compiler/ReflectionDiscovery.Configurators.cs
@@ -15,10 +15,6 @@ namespace NBench.Sdk.Compiler
         /// Cache of <see cref="MeasurementAttribute"/> types and their "best fitting" <see cref="IMeasurementConfigurator"/> type
         /// </summary>
         private readonly ConcurrentDictionary<Type, Type> _measurementConfiguratorTypes = new ConcurrentDictionary<Type, Type>();
-        private static readonly Lazy<IReadOnlyList<Type>> AllConfigurators = new Lazy<IReadOnlyList<Type>>(() => LoadAllTypeConfigurators().ToList(), true);
-
-        // force the lazy loading of all configurators; should only happen the first time a ReflectionDiscovery class is instantiated
-        private readonly IReadOnlyList<Type> _configurators = AllConfigurators.Value;
 
         /// <summary>
         /// Finds a matching <see cref="IMeasurementConfigurator{T}"/> type for a given type of <see cref="MeasurementAttribute"/>
@@ -39,7 +35,7 @@ namespace NBench.Sdk.Compiler
 
             // search for a match
             var match = FindBestMatchingConfiguratorForMeasurement(measurementType, 
-                specificAssembly == null ? _configurators : _configurators.Where(x=> x.Assembly.Equals(specificAssembly)));
+                specificAssembly == null ? LoadAllTypeConfigurators() : LoadAllTypeConfigurators().Where(x=> x.Assembly.Equals(specificAssembly)));
 
             // cache the result
             _measurementConfiguratorTypes[measurementType] = match;

--- a/tests/NBench.PerformanceCounters.Tests.Performance/NBench.PerformanceCounters.Tests.Performance.csproj
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/NBench.PerformanceCounters.Tests.Performance.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3112B845-6A64-4AD2-9FA9-88F47BE980C8}</ProjectGuid>
+    <ProjectGuid>{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NBench.PerformanceCounters</RootNamespace>
-    <AssemblyName>NBench.PerformanceCounters</AssemblyName>
+    <RootNamespace>NBench.PerformanceCounters.Tests.Performance</RootNamespace>
+    <AssemblyName>NBench.PerformanceCounters.Tests.Performance</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -32,24 +32,24 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\SharedAssemblyInfo.cs">
-      <Link>Properties\SharedAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="Collection\PerformanceCounterSelector.cs" />
-    <Compile Include="Metrics\PerformanceCounterBenchmarkSetting.cs" />
-    <Compile Include="Metrics\PerformanceCounterMetricName.cs" />
-    <Compile Include="PerformanceCounterMeasurementAttribute.cs" />
-    <Compile Include="Collection\PerformanceCounterRawValueCollector.cs" />
-    <Compile Include="PerformanceCounterMeasurementConfigurator.cs" />
-    <Compile Include="PerformanceCounterThroughputAssertionAttribute.cs" />
-    <Compile Include="PerformanceCounterTotalAssertionAttribute.cs" />
+    <Compile Include="ProcessJitSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TotalProcessMemorySpecs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NBench\NBench.csproj">
+    <ProjectReference Include="..\..\src\NBench.PerformanceCounters\NBench.PerformanceCounters.csproj">
+      <Project>{3112b845-6a64-4ad2-9fa9-88f47be980c8}</Project>
+      <Name>NBench.PerformanceCounters</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NBench\NBench.csproj">
       <Project>{4e0b1852-7b6d-49e7-9939-a315d086b094}</Project>
       <Name>NBench</Name>
     </ProjectReference>

--- a/tests/NBench.PerformanceCounters.Tests.Performance/ProcessJitSpec.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/ProcessJitSpec.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+
+namespace NBench.PerformanceCounters.Tests.Performance
+{
+    public class ProcessJitSpec
+    {
+        [PerfBenchmark(Description = "Capture the amount of .NET CLR JIT compiler time being used",
+            TestMode = TestMode.Measurement, RunMode = RunMode.Iterations, NumberOfIterations = 13)]
+        [PerformanceCounterMeasurement(".NET CLR Jit", "% Time in Jit", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "% Time in Jit")]
+        [PerformanceCounterMeasurement(".NET CLR Jit", "# of Methods Jitted", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "methods")]
+        public void TimeInJit()
+        {
+            Func<int, bool> isEven = i => i%2 == 0;
+            foreach (var i in Enumerable.Range(0, 10000))
+                isEven(i);
+        }
+    }
+}

--- a/tests/NBench.PerformanceCounters.Tests.Performance/Properties/AssemblyInfo.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NBench.PerformanceCounters.Tests.Performance")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NBench.PerformanceCounters.Tests.Performance")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fd7be8f5-460f-4a3d-a479-e4af36c4eed5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NBench.PerformanceCounters.Tests.Performance/TotalProcessMemorySpecs.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/TotalProcessMemorySpecs.cs
@@ -1,0 +1,15 @@
+﻿namespace NBench.PerformanceCounters.Tests.Performance
+{
+    public class TotalProcessMemorySpecs
+    {
+        [PerfBenchmark(Description = "Capture the total amount of process memory currently in use", 
+            TestMode = TestMode.Measurement, RunMode = RunMode.Iterations, NumberOfIterations = 13)]
+        [PerformanceCounterMeasurement("Memory", "% Committed Bytes In Use", UnitName = "bytes")]
+        [PerformanceCounterMeasurement(".NET CLR Memory", "# Total committed Bytes", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "bytes")]
+        public void TotalProcessMemoryInUse()
+        {
+            // useless work that allocates memory
+            var data = new byte[ByteConstants.SixtyFourKb];
+        }
+    }
+}


### PR DESCRIPTION
Discovered that we weren't logging any metrics for PerformanceCounters as a result of our `IMetricConfigurator` caching we were performing on startup. Disabled caching so we can dynamically pick up new assemblies as they're needed rather than do it all upfront.