### PR TITLE
PerformanceCounter object pooling, integration tests, floating point collector output

### DIFF
--- a/NBench.sln
+++ b/NBench.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PerformanceCounters"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PeformanceCounters.Tests.End2End", "tests\NBench.PeformanceCounters.Tests.End2End\NBench.PeformanceCounters.Tests.End2End.csproj", "{416A4BAD-459C-4896-A44C-4C2344EBE154}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PerformanceCounters.Tests.Performance", "tests\NBench.PerformanceCounters.Tests.Performance\NBench.PerformanceCounters.Tests.Performance.csproj", "{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{416A4BAD-459C-4896-A44C-4C2344EBE154}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,5 +96,6 @@ Global
 		{E3730D65-70AE-4055-A291-800044C48FDD} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{96FCB3AB-8C76-4BD0-B97F-1239E5FF5C5C} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{416A4BAD-459C-4896-A44C-4C2344EBE154} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
+		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 	EndGlobalSection
 EndGlobal

--- a/src/NBench.PerformanceCounters/Collection/CachedPerformanceCounterProxy.cs
+++ b/src/NBench.PerformanceCounters/Collection/CachedPerformanceCounterProxy.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+
+namespace NBench.PerformanceCounters.Collection
+{
+    /// <summary>
+    /// Cached, reference counted implementation of <see cref="IPerformanceCounterProxy"/>
+    /// </summary>
+    public class CachedPerformanceCounterProxy : IPerformanceCounterProxy
+    {
+
+        private readonly Func<IPerformanceCounterProxy> _getUnderlying;
+        private int _referenceCount;
+        public int CurrentReferenceCount => _referenceCount;
+
+        public CachedPerformanceCounterProxy(Func<IPerformanceCounterProxy> getUnderlying)
+        {
+            _getUnderlying = getUnderlying;
+        }
+
+        public void Dispose()
+        {
+            if (CurrentReferenceCount < 0)
+            {
+                _getUnderlying()?.Dispose();
+            }
+            else
+            {
+                Release();
+            }
+        }
+
+        public bool WasDisposed => _getUnderlying().WasDisposed;
+        public bool CanWarmup => _getUnderlying().CanWarmup;
+
+        public double Collect()
+        {
+            return _getUnderlying().Collect();
+        }
+
+        public void Touch()
+        {
+            Interlocked.Increment(ref _referenceCount);
+        }
+
+        public void Release()
+        {
+            Interlocked.Decrement(ref _referenceCount);
+        }
+    }
+}

--- a/src/NBench.PerformanceCounters/Collection/EmptyPerformanceCounterProxy.cs
+++ b/src/NBench.PerformanceCounters/Collection/EmptyPerformanceCounterProxy.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace NBench.PerformanceCounters.Collection
+{
+    /// <summary>
+    /// Special case pattern - used when we can't find a <see cref="IPerformanceCounterProxy"/>
+    /// inside the <see cref="PerformanceCounterCache"/>.
+    /// </summary>
+    public class EmptyPerformanceCounterProxy : IPerformanceCounterProxy
+    {
+        private EmptyPerformanceCounterProxy() { }
+
+        public static readonly EmptyPerformanceCounterProxy Instance = new EmptyPerformanceCounterProxy();
+
+        public void Dispose()
+        {
+            
+        }
+
+        public bool WasDisposed => true;
+        public bool CanWarmup => false;
+        public double Collect()
+        {
+            throw new NotImplementedException("Should not have had an EmptyPerformanceCounterProxy make it into benchmark");
+        }
+    }
+}

--- a/src/NBench.PerformanceCounters/Collection/IPerformanceCounterProxy.cs
+++ b/src/NBench.PerformanceCounters/Collection/IPerformanceCounterProxy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace NBench.PerformanceCounters.Collection
+{
+    /// <summary>
+    /// Proxy wrapper for <see cref="PerformanceCounter"/>s - designed to help mitigate
+    /// against "slow start" issues for counters.
+    /// </summary>
+    public interface IPerformanceCounterProxy : IDisposable
+    {
+        /// <summary>
+        /// Have we disposed this counter already?
+        /// </summary>
+        bool WasDisposed { get; }
+
+        /// <summary>
+        /// A flag that indicates of the underlying counter was able to start successfully
+        /// </summary>
+        bool CanWarmup { get; }
+
+        /// <summary>
+        /// Gets the raw value from the underlying <see cref="PerformanceCounter"/>
+        /// </summary>
+        /// <returns>A <see cref="long"/> representing the counter's value</returns>
+        double Collect();
+    }
+}

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterCache.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterCache.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using NBench.Metrics;
+
+namespace NBench.PerformanceCounters.Collection
+{
+    /// <summary>
+    /// Used to warm up and cache <see cref="PerformanceCounter"/> instances
+    /// </summary>
+    internal sealed class PerformanceCounterCache
+    {
+       private readonly IDictionary<MetricName, CachedPerformanceCounterProxy> _cachedCounters;
+
+        public PerformanceCounterCache() : this(new Dictionary<MetricName, CachedPerformanceCounterProxy>()) { }
+
+        public PerformanceCounterCache(IDictionary<MetricName, CachedPerformanceCounterProxy> cachedCounters)
+        {
+            _cachedCounters = cachedCounters;
+        }
+
+        public bool Exists(MetricName name)
+        {
+            // exists and is not disposed
+            return _cachedCounters.ContainsKey(name) && !_cachedCounters[name].WasDisposed;
+        }
+
+        public bool Put(MetricName name, IPerformanceCounterProxy concreteCounter)
+        {
+            if (!Exists(name))
+            {
+                _cachedCounters[name] = new CachedPerformanceCounterProxy(() => concreteCounter);
+                return true;
+            }
+
+            // already exists - not overriding
+            return false;
+        }
+
+        public IPerformanceCounterProxy Get(MetricName name)
+        {
+            if (!Exists(name))
+            {
+                return EmptyPerformanceCounterProxy.Instance;
+            }
+            var counter = _cachedCounters[name];
+            counter.Touch(); // increment reference count
+            return counter;
+        }
+    }
+}

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterProxy.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterProxy.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+
+namespace NBench.PerformanceCounters.Collection
+{
+    /// <summary>
+    /// Concrete implementation of <see cref="IPerformanceCounterProxy"/> that recreates the underlying
+    /// <see cref="PerformanceCounter"/> on fault up to a maxmium limit.
+    /// 
+    /// NOT THREAD SAFE.
+    /// </summary>
+    public class PerformanceCounterProxy : IPerformanceCounterProxy
+    {
+        /// <summary>
+        /// Our instance of the concrete counter - will be recreated on fault
+        /// </summary>
+        private PerformanceCounter _counter;
+
+        private readonly Func<PerformanceCounter> _counterFactory; // recreate the counter on error
+
+        public PerformanceCounterProxy(Func<PerformanceCounter> counterFactory)
+        {
+            Contract.Requires(counterFactory != null);
+            _counterFactory = counterFactory;
+            WasDisposed = false;
+        }
+
+        public bool WasDisposed { get; private set; }
+
+        public bool CanWarmup
+        {
+            get
+            {
+                try
+                {
+                    // will invoke an exception if the counter was created too quickly
+                    var counter = GetOrCreate();
+                    var value = counter.RawValue;
+                    return true;
+                }
+                catch (Exception ex)
+                { 
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Return the raw value of the counter
+        /// </summary>
+        /// <returns>A long integer representing <see cref="PerformanceCounter.RawValue"/></returns>
+        public double Collect()
+        {
+            var counter = GetOrCreate();
+            try
+            {
+                var val = counter.NextValue();
+                return val;
+            }
+            catch (Exception)
+            {
+                // recreate counter
+                DisposeCounter();
+                return 0;
+            }
+        }
+
+        private PerformanceCounter GetOrCreate()
+        {
+            if (_counter == null && !WasDisposed)
+            {
+                //create the counter
+                _counter = _counterFactory();
+            }
+
+            return _counter;
+        }
+
+        public void Dispose(bool isDisposing)
+        {
+            if (isDisposing && !WasDisposed)
+            {
+
+                try
+                {
+                    DisposeCounter();
+                }
+                catch //supress errors - we do not care
+                {
+                }
+                finally
+                {
+                    WasDisposed = true;
+                }
+            }
+        }
+
+        private void DisposeCounter()
+        {
+            _counter?.Close();
+            _counter?.Dispose();
+            _counter = null;
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+    }
+}

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterSelector.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterSelector.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Threading;
 using NBench.Collection;
 using NBench.Metrics;
 using NBench.PerformanceCounters.Metrics;
@@ -15,6 +17,8 @@ namespace NBench.PerformanceCounters.Collection
     /// </summary>
     public class PerformanceCounterSelector : MetricsCollectorSelector
     {
+        private readonly PerformanceCounterCache _cache = new PerformanceCounterCache();
+
         public PerformanceCounterSelector() : this(PerformanceCounterMetricName.DefaultName) { }
 
         public PerformanceCounterSelector(MetricName name) : base(name)
@@ -25,6 +29,14 @@ namespace NBench.PerformanceCounters.Collection
         {
         }
 
+        public static bool CanFindPerformanceCounter(PerformanceCounterMetricName name)
+        {
+            var hasInstance = !string.IsNullOrEmpty(name.InstanceName);
+            return hasInstance
+                ? PerformanceCounterCategory.InstanceExists(name.InstanceName, name.CategoryName)
+                : PerformanceCounterCategory.CounterExists(name.CounterName, name.CategoryName);
+        }
+
         public override MetricCollector Create(RunMode runMode, WarmupData warmup, IBenchmarkSetting setting)
         {
             Contract.Assert(setting != null);
@@ -32,17 +44,62 @@ namespace NBench.PerformanceCounters.Collection
             var counterBenchmarkSetting = setting as PerformanceCounterBenchmarkSetting;
             var name = counterBenchmarkSetting.PerformanceCounterMetric;
 
-            try
+            // re-use the PerformanceCounter objects in our pool if possible
+            if (_cache.Exists(name))
+                return new PerformanceCounterValueCollector(name, name.UnitName ?? MetricNames.DefaultUnitName, _cache.Get(name), true);
+
+            // otherwise, warm up new ones
+            var maxRetries = 3;
+            var currentRetries = 0;
+
+            if (!PerformanceCounterCategory.CounterExists(name.CounterName, name.CategoryName))
+                throw new NBenchException($"Performance counter {name.ToHumanFriendlyString()} is not registered on this machine. Please create it first.");
+
+            // check to see that the instance we're interested in is registered
+            if (!string.IsNullOrEmpty(name.InstanceName))
             {
-                var performanceCounter = new PerformanceCounter(name.CategoryName, name.CounterName,
+                var categories = PerformanceCounterCategory.GetCategories().Where(x => x.CategoryType == PerformanceCounterCategoryType.MultiInstance).ToList();
+#if DEBUG
+                Console.WriteLine("---- DEBUG -----");
+                Console.WriteLine("{0} multi-instance categories detected", categories.Count);
+#endif
+                var category = categories.Single(x => x.CategoryName == name.CategoryName);
+                var instances = category.GetInstanceNames();
+
+                if (!instances.Contains(name.InstanceName))
+                {
+#if DEBUG
+                    Console.WriteLine("---- DEBUG -----");
+                    Console.WriteLine("Multi-instance? {0}", category.CategoryType);
+                    foreach (var instance in instances)
+                        Console.WriteLine(instance);
+#endif
+                    throw new NBenchException($"Performance counter {name.CategoryName}:{name.CounterName} exists, but we could not find an instance {name.InstanceName}.");
+                }
+
+            }
+
+            var proxy = new PerformanceCounterProxy(() =>
+            {
+                var counter = new PerformanceCounter(name.CategoryName, name.CounterName,
                     name.InstanceName ?? string.Empty, true);
 
-                return new PerformanceCounterMetricCollector(name, name.UnitName ?? MetricNames.DefaultUnitName, performanceCounter, true);
-            }
-            catch (Exception ex)
+                return counter;
+            });
+            while (!CanFindPerformanceCounter(name) && currentRetries <= maxRetries)
             {
-                throw new NBenchException($"Failed to create PerformanceCounterMeasurement {name.ToHumanFriendlyString()} - internal error while creating performance counter.", ex);
+                Thread.Sleep(TimeSpan.FromMilliseconds(1000 + 100 * (currentRetries ^ 2))); // little bit of exponential backoff
+                if (proxy.CanWarmup)
+                    break;
+                currentRetries++;
             }
+
+            if (!proxy.CanWarmup)
+                throw new NBenchException($"Performance counter {name.ToHumanFriendlyString()} is not registered on this machine. Please create it first.");
+
+            // cache this performance counter and pool it for re-use
+            _cache.Put(name, proxy);
+            return new PerformanceCounterValueCollector(name, name.UnitName ?? MetricNames.DefaultUnitName, _cache.Get(name), true);
         }
     }
 }

--- a/src/NBench.PerformanceCounters/Collection/PerformanceCounterValueCollector.cs
+++ b/src/NBench.PerformanceCounters/Collection/PerformanceCounterValueCollector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using NBench.Collection;
 using NBench.Metrics;
@@ -10,32 +11,41 @@ namespace NBench.PerformanceCounters.Collection
     /// <summary>
     ///     A <see cref="MetricCollector" /> implementation that uses a <see cref="PerformanceCounter" />
     ///     internally to record various system metrics.
+    /// 
+    /// Captures the RAW VALUE from performance counters.
     /// </summary>
-    public class PerformanceCounterMetricCollector : MetricCollector
+    public class PerformanceCounterValueCollector : MetricCollector
     {
-        private PerformanceCounter _counter;
+        protected IPerformanceCounterProxy Counter;
 
-        public PerformanceCounterMetricCollector(MetricName name, string unitName, PerformanceCounter counter,
+        public PerformanceCounterValueCollector(MetricName name, string unitName, IPerformanceCounterProxy counter,
             bool disposesCounter) : base(name, unitName)
         {
-            _counter = counter;
+            Counter = counter;
             DisposesCounter = disposesCounter;
         }
 
         public bool DisposesCounter { get; }
 
-        public override long Collect()
+        public override double Collect()
         {
-            return _counter.RawValue;
+            try
+            {
+                return Counter.Collect();
+            }
+            catch (Exception ex)
+            {
+                throw new NBenchException($"Failed to get value for PerformanceCounter {Name.ToHumanFriendlyString()} due to underlying error.", ex);
+            }
         }
 
         protected override void DisposeInternal()
         {
             if (DisposesCounter)
             {
-                _counter.Dispose();
+                Counter.Dispose();
             }
-            _counter = null;
+            Counter = null;
         }
     }
 }

--- a/src/NBench.PerformanceCounters/Metrics/PerformanceCounterMetricName.cs
+++ b/src/NBench.PerformanceCounters/Metrics/PerformanceCounterMetricName.cs
@@ -95,5 +95,10 @@ namespace NBench.PerformanceCounters.Metrics
                 return $"[PerformanceCounter] {CategoryName}:{CounterName}:{InstanceName}";
             return $"[PerformanceCounter] {CategoryName}:{CounterName}";
         }
+
+        public override string ToString()
+        {
+            return ToHumanFriendlyString();
+        }
     }
 }

--- a/src/NBench.PerformanceCounters/PerformanceCounterMeasurementConfigurator.cs
+++ b/src/NBench.PerformanceCounters/PerformanceCounterMeasurementConfigurator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 using NBench.Collection;
 using NBench.Metrics;
 using NBench.PerformanceCounters.Collection;
@@ -17,13 +18,54 @@ namespace NBench.PerformanceCounters
     {
         public static readonly PerformanceCounterSelector Selector = new PerformanceCounterSelector();
 
+        public static readonly Lazy<string> ProcessId = new Lazy<string>(GetProcessId, true);
+
+        /// <summary>
+        /// Due to a bunch of fun hijinks around multiple processes all having the same name, we
+        /// have to do some extra legwork to find the correct performance counter instance name that corresponds
+        /// to this specific instance of NBench.
+        /// </summary>
+        public static string GetProcessId()
+        {
+            var baseName = Process.GetCurrentProcess().ProcessName;
+            var pid = Process.GetCurrentProcess().Id;
+            var processIndex = 0; //the very first process doesn't have a "#N" appended to the back of it
+            var expectedCounterName = processIndex == 0 ? baseName : baseName + "#" + processIndex;
+            while (true)
+            {
+                try
+                {
+                    var pc = new PerformanceCounter("Process", "ID Process", expectedCounterName, true);
+                    if (pid == (int) pc.NextValue())
+                    {
+                        break;
+                    }
+
+                    processIndex++;
+                    expectedCounterName = processIndex == 0 ? baseName : baseName + "#" + processIndex;
+                    try { pc.Dispose(); }
+                    catch { } //supress exceptions
+                }
+                catch (Exception ex)
+                {
+                    if (ex.Message.Contains($"{expectedCounterName} does not exist in the specified Category"))
+                    {
+                        break;
+                    }
+                    throw;
+                }
+            }
+
+            return expectedCounterName;
+        }
+
         public override MetricName GetName(PerformanceCounterMeasurementAttribute instance)
         {
             Contract.Requires(instance != null);
 
             // Grab a dynamic value for the instance name of this performance counter
             var instanceName = string.Equals(instance.InstanceName, NBenchPerformanceCounterConstants.CurrentProcessName)
-                ? Process.GetCurrentProcess().ProcessName
+                ? ProcessId.Value
                 : instance.InstanceName;
 
             return new PerformanceCounterMetricName(instance.CategoryName, instance.CounterName, instanceName, instance.UnitName);

--- a/src/NBench.Runner/NBench.Runner.csproj
+++ b/src/NBench.Runner/NBench.Runner.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/NBench.Runner/Program.cs
+++ b/src/NBench.Runner/Program.cs
@@ -40,7 +40,6 @@ namespace NBench.Runner
 				package.ConfigurationFile = CommandLine.GetProperty("configuration");
 
 			package.Validate();
-
             var result = TestRunner.Run(package);
        
             return result.AllTestsPassed ? 0 : -1;

--- a/src/NBench/Collection/Counters/CounterMetricCollector.cs
+++ b/src/NBench/Collection/Counters/CounterMetricCollector.cs
@@ -23,7 +23,7 @@ namespace NBench.Collection
             _counter = counter;
         }
 
-        public override long Collect()
+        public override double Collect()
         {
             return _counter.Current;
         }

--- a/src/NBench/Collection/GarbageCollection/GcCollectionsPerGenerationCollector.cs
+++ b/src/NBench/Collection/GarbageCollection/GcCollectionsPerGenerationCollector.cs
@@ -26,7 +26,7 @@ namespace NBench.Collection.Memory
         /// </summary>
         public int Generation { get; }
 
-        public override long Collect()
+        public override double Collect()
         {
             return GC.CollectionCount(Generation);
         }

--- a/src/NBench/Collection/Memory/GcTotalMemoryCollector.cs
+++ b/src/NBench/Collection/Memory/GcTotalMemoryCollector.cs
@@ -24,7 +24,7 @@ namespace NBench.Collection.Memory
         {
         }
 
-        public override long Collect()
+        public override double Collect()
         {
             /*
              * We intentionally don't allow the garbage collector to collect anything

--- a/src/NBench/Collection/MetricCollector.cs
+++ b/src/NBench/Collection/MetricCollector.cs
@@ -33,7 +33,7 @@ namespace NBench.Collection
         /// <summary>
         /// Collects the value of this metric
         /// </summary>
-        public abstract long Collect();
+        public abstract double Collect();
 
         public bool WasDisposed { get; private set; }
 

--- a/src/NBench/Metrics/MetricMeasurement.cs
+++ b/src/NBench/Metrics/MetricMeasurement.cs
@@ -10,7 +10,9 @@ namespace NBench.Metrics
     /// </summary>
     public struct MetricMeasurement
     {
-        public MetricMeasurement(long elapsedTicks, long metricValue)
+        public const double PrecisionTolerance = 0.000001d;
+
+        public MetricMeasurement(long elapsedTicks, double metricValue)
         {
             ElapsedTicks = elapsedTicks;
             MetricValue = metricValue;
@@ -18,11 +20,11 @@ namespace NBench.Metrics
 
         public long ElapsedTicks { get; }
 
-        public long MetricValue { get; }
+        public double MetricValue { get; }
 
         public bool Equals(MetricMeasurement other)
         {
-            return ElapsedTicks == other.ElapsedTicks && MetricValue == other.MetricValue;
+            return ElapsedTicks == other.ElapsedTicks && Math.Abs(MetricValue - other.MetricValue) < PrecisionTolerance;
         }
 
         public override bool Equals(object obj)

--- a/src/NBench/Sdk/Compiler/ReflectionDiscovery.Configurators.cs
+++ b/src/NBench/Sdk/Compiler/ReflectionDiscovery.Configurators.cs
@@ -15,10 +15,6 @@ namespace NBench.Sdk.Compiler
         /// Cache of <see cref="MeasurementAttribute"/> types and their "best fitting" <see cref="IMeasurementConfigurator"/> type
         /// </summary>
         private readonly ConcurrentDictionary<Type, Type> _measurementConfiguratorTypes = new ConcurrentDictionary<Type, Type>();
-        private static readonly Lazy<IReadOnlyList<Type>> AllConfigurators = new Lazy<IReadOnlyList<Type>>(() => LoadAllTypeConfigurators().ToList(), true);
-
-        // force the lazy loading of all configurators; should only happen the first time a ReflectionDiscovery class is instantiated
-        private readonly IReadOnlyList<Type> _configurators = AllConfigurators.Value;
 
         /// <summary>
         /// Finds a matching <see cref="IMeasurementConfigurator{T}"/> type for a given type of <see cref="MeasurementAttribute"/>
@@ -39,7 +35,7 @@ namespace NBench.Sdk.Compiler
 
             // search for a match
             var match = FindBestMatchingConfiguratorForMeasurement(measurementType, 
-                specificAssembly == null ? _configurators : _configurators.Where(x=> x.Assembly.Equals(specificAssembly)));
+                specificAssembly == null ? LoadAllTypeConfigurators() : LoadAllTypeConfigurators().Where(x=> x.Assembly.Equals(specificAssembly)));
 
             // cache the result
             _measurementConfiguratorTypes[measurementType] = match;

--- a/tests/NBench.PerformanceCounters.Tests.Performance/NBench.PerformanceCounters.Tests.Performance.csproj
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/NBench.PerformanceCounters.Tests.Performance.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3112B845-6A64-4AD2-9FA9-88F47BE980C8}</ProjectGuid>
+    <ProjectGuid>{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NBench.PerformanceCounters</RootNamespace>
-    <AssemblyName>NBench.PerformanceCounters</AssemblyName>
+    <RootNamespace>NBench.PerformanceCounters.Tests.Performance</RootNamespace>
+    <AssemblyName>NBench.PerformanceCounters.Tests.Performance</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -32,29 +32,25 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\SharedAssemblyInfo.cs">
-      <Link>Properties\SharedAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="Collection\CachedPerformanceCounterProxy.cs" />
-    <Compile Include="Collection\EmptyPerformanceCounterProxy.cs" />
-    <Compile Include="Collection\IPerformanceCounterProxy.cs" />
-    <Compile Include="Collection\PerformanceCounterCache.cs" />
-    <Compile Include="Collection\PerformanceCounterProxy.cs" />
-    <Compile Include="Collection\PerformanceCounterSelector.cs" />
-    <Compile Include="Metrics\PerformanceCounterBenchmarkSetting.cs" />
-    <Compile Include="Metrics\PerformanceCounterMetricName.cs" />
-    <Compile Include="PerformanceCounterMeasurementAttribute.cs" />
-    <Compile Include="Collection\PerformanceCounterValueCollector.cs" />
-    <Compile Include="PerformanceCounterMeasurementConfigurator.cs" />
-    <Compile Include="PerformanceCounterThroughputAssertionAttribute.cs" />
-    <Compile Include="PerformanceCounterTotalAssertionAttribute.cs" />
+    <Compile Include="ProcessJitSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ThrowExceptionsSpec.cs" />
+    <Compile Include="TotalProcessMemorySpecs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NBench\NBench.csproj">
+    <ProjectReference Include="..\..\src\NBench.PerformanceCounters\NBench.PerformanceCounters.csproj">
+      <Project>{3112b845-6a64-4ad2-9fa9-88f47be980c8}</Project>
+      <Name>NBench.PerformanceCounters</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NBench\NBench.csproj">
       <Project>{4e0b1852-7b6d-49e7-9939-a315d086b094}</Project>
       <Name>NBench</Name>
     </ProjectReference>

--- a/tests/NBench.PerformanceCounters.Tests.Performance/ProcessJitSpec.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/ProcessJitSpec.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+
+namespace NBench.PerformanceCounters.Tests.Performance
+{
+    public class ProcessJitSpec
+    {
+        [PerfBenchmark(Description = "Capture the amount of .NET CLR JIT compiler time being used",
+            TestMode = TestMode.Measurement, RunMode = RunMode.Iterations, NumberOfIterations = 13)]
+        //[PerformanceCounterMeasurement(".NET CLR Jit", "% Time in Jit", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "% Time in Jit")]
+        [PerformanceCounterMeasurement(".NET CLR Jit", "# of Methods Jitted", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "methods")]
+        public void TimeInJit()
+        {
+            Func<int, bool> isEven = i => i%2 == 0;
+            foreach (var i in Enumerable.Range(0, 10000))
+                isEven(i);
+        }
+    }
+}

--- a/tests/NBench.PerformanceCounters.Tests.Performance/Properties/AssemblyInfo.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NBench.PerformanceCounters.Tests.Performance")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NBench.PerformanceCounters.Tests.Performance")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fd7be8f5-460f-4a3d-a479-e4af36c4eed5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NBench.PerformanceCounters.Tests.Performance/ThrowExceptionsSpec.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/ThrowExceptionsSpec.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace NBench.PerformanceCounters.Tests.Performance
+{
+    /// <summary>
+    /// Track the number of exceptions thrown in a given benchmark
+    /// </summary>
+    public class ThrownExceptionsBenchmark
+    {
+        [PerfBenchmark(Description = "Track to see how many exceptions per second we can log using Windows Performance Counters", NumberOfIterations = 13, RunMode = RunMode.Throughput, TestMode = TestMode.Test, RunTimeMilliseconds = 200)]
+        [PerformanceCounterMeasurement(".NET CLR Exceptions", "# of Exceps Thrown", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        [PerformanceCounterThroughputAssertion(".NET CLR Exceptions", "# of Exceps Thrown", MustBe.GreaterThanOrEqualTo, 10.0d, InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        [PerformanceCounterTotalAssertion(".NET CLR Exceptions", "# of Exceps Thrown", MustBe.GreaterThanOrEqualTo, 10.0d, InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        public void ThrowingMethod()
+        {
+            try
+            {
+                throw new ApplicationException("WEEEEEEEEEE");
+            }
+            catch
+            {
+                // supress the error so NBench doesn't stop running the benchmark
+            }
+        }
+
+        [PerfBenchmark(Description = "Track to ensure no exceptions are thrown Windows Performance Counters", NumberOfIterations = 13, RunMode = RunMode.Throughput, TestMode = TestMode.Test, RunTimeMilliseconds = 200)]
+        [PerformanceCounterMeasurement(".NET CLR Exceptions", "# of Exceps Thrown", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        [PerformanceCounterThroughputAssertion(".NET CLR Exceptions", "# of Exceps Thrown", MustBe.LessThanOrEqualTo, 10.0d, InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        [PerformanceCounterTotalAssertion(".NET CLR Exceptions", "# of Exceps Thrown", MustBe.LessThanOrEqualTo, 10.0d, InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "exceptions")]
+        public void NoThrowingMethod()
+        {
+            // do nothing
+        }
+    }
+}

--- a/tests/NBench.PerformanceCounters.Tests.Performance/TotalProcessMemorySpecs.cs
+++ b/tests/NBench.PerformanceCounters.Tests.Performance/TotalProcessMemorySpecs.cs
@@ -1,0 +1,15 @@
+﻿namespace NBench.PerformanceCounters.Tests.Performance
+{
+    public class TotalProcessMemorySpecs
+    {
+        [PerfBenchmark(Description = "Capture the total amount of process memory currently in use", 
+            TestMode = TestMode.Measurement, RunMode = RunMode.Iterations, NumberOfIterations = 13)]
+        [PerformanceCounterMeasurement("Memory", "% Committed Bytes In Use", UnitName = "bytes")]
+        [PerformanceCounterMeasurement(".NET CLR Memory", "# Total committed Bytes", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "bytes")]
+        public void TotalProcessMemoryInUse()
+        {
+            // useless work that allocates memory
+            var data = new byte[ByteConstants.SixtyFourKb];
+        }
+    }
+}

--- a/tests/NBench.Tests/Collection/Memory/GcTotalMemoryCollectorSpecs.cs
+++ b/tests/NBench.Tests/Collection/Memory/GcTotalMemoryCollectorSpecs.cs
@@ -28,13 +28,13 @@ namespace NBench.Tests.Collection.Memory
         {
             var totalMemoryCollector = new GcTotalMemoryCollector(MetricNames.TotalMemoryAllocated);
            
-            long initialReading = totalMemoryCollector.Collect();
+            var initialReading = totalMemoryCollector.Collect();
             {
                 var bytes = new byte[bytesAllocated];
                 bytes = null;
             }
-            long finalReading = totalMemoryCollector.Collect();
-            long delta = finalReading - initialReading;
+            var finalReading = totalMemoryCollector.Collect();
+            var delta = finalReading - initialReading;
             Assert.True(finalReading > initialReading, "Should be: finalReading > initialReading");
             double actualDifference = Math.Abs(delta - bytesAllocated)/(double)bytesAllocated;
             Assert.True(actualDifference <= accuracy,

--- a/tests/NBench.Tests/TestMetricCollector.cs
+++ b/tests/NBench.Tests/TestMetricCollector.cs
@@ -17,7 +17,7 @@ namespace NBench.Tests
         {
         }
 
-        public override long Collect()
+        public override double Collect()
         {
             return CollectorValue;
         }


### PR DESCRIPTION
added some NBench.PerformanceCounter integration tests
updated all collectors to use floating point
made it possible to identify the correct NBench process instance
added object pooling for PerformanceCounter