### PR TITLE
added the IBenchmarkAssertionRunner interface

### DIFF
--- a/src/NBench/MustBe.cs
+++ b/src/NBench/MustBe.cs
@@ -4,7 +4,7 @@
 namespace NBench
 {
     /// <summary>
-    /// Comparison and test types used by NBench for performing performance test assertions
+    /// Comparison and test types used by NBench for performing performance test BenchmarkAssertions
     /// </summary>
     public enum MustBe
     {

--- a/src/NBench/NBench.csproj
+++ b/src/NBench/NBench.csproj
@@ -117,12 +117,13 @@
     <Compile Include="Reporting\Targets\MarkdownBenchmarkOutput.cs" />
     <Compile Include="Sdk\Assertion.cs" />
     <Compile Include="Sdk\AssertionResult.cs" />
-    <Compile Include="Sdk\AssertionRunner.cs" />
+    <Compile Include="Sdk\DefaultBenchmarkAssertionRunner.cs" />
     <Compile Include="Sdk\AssertionType.cs" />
     <Compile Include="BenchmarkContext.cs" />
     <Compile Include="Sdk\BenchmarkBuilder.cs" />
     <Compile Include="Metrics\Counters\CounterMeasurementConfigurator.cs" />
     <Compile Include="Sdk\Compiler\ReflectionDiscovery.Configurators.cs" />
+    <Compile Include="Sdk\IBenchmarkAssertionRunner.cs" />
     <Compile Include="Sdk\IMeasurementConfigurator.cs" />
     <Compile Include="Sdk\MeasurementConfigurator.cs" />
     <Compile Include="Sdk\BenchmarkConstants.cs" />

--- a/src/NBench/PerformanceBenchmark.cs
+++ b/src/NBench/PerformanceBenchmark.cs
@@ -17,7 +17,7 @@ namespace NBench
         Test,
 
         /// <summary>
-        /// Performs no assertions - just records the metrics and writes them to the log
+        /// Performs no BenchmarkAssertions - just records the metrics and writes them to the log
         /// </summary>
         Measurement,
     }

--- a/src/NBench/Reporting/Targets/ActionBenchmarkOutput.cs
+++ b/src/NBench/Reporting/Targets/ActionBenchmarkOutput.cs
@@ -6,7 +6,7 @@ using System;
 namespace NBench.Reporting.Targets
 {
     /// <summary>
-    /// An <see cref="IBenchmarkOutput"/> designed to run assertions against the data we collect on each run and in the final benchmark.
+    /// An <see cref="IBenchmarkOutput"/> designed to run BenchmarkAssertions against the data we collect on each run and in the final benchmark.
     /// </summary>
     public sealed class ActionBenchmarkOutput : IBenchmarkOutput
     {

--- a/src/NBench/Reporting/Targets/MarkdownBenchmarkOutput.cs
+++ b/src/NBench/Reporting/Targets/MarkdownBenchmarkOutput.cs
@@ -96,7 +96,7 @@ namespace NBench.Reporting.Targets
             sb.AppendFormat(BuildRunTable(results.Data.Runs));
             if (results.AssertionResults.Count > 0)
             {
-                sb.AppendLine("## Assertions");
+                sb.AppendLine("## BenchmarkAssertions");
                 sb.AppendLine();
                 foreach (var assertion in results.AssertionResults)
                 {

--- a/src/NBench/Sdk/AssertionType.cs
+++ b/src/NBench/Sdk/AssertionType.cs
@@ -4,7 +4,7 @@
 namespace NBench.Sdk
 {
     /// <summary>
-    /// Different types of assertions we might use against metrics
+    /// Different types of BenchmarkAssertions we might use against metrics
     /// </summary>
     public enum AssertionType
     {

--- a/src/NBench/Sdk/Benchmark.cs
+++ b/src/NBench/Sdk/Benchmark.cs
@@ -36,7 +36,24 @@ namespace NBench.Sdk
         private int _pendingIterations;
         protected WarmupData WarmupData = WarmupData.PreWarmup;
 
-        public Benchmark(BenchmarkSettings settings, IBenchmarkInvoker invoker, IBenchmarkOutput writer)
+        /// <summary>
+        /// Backwards-compatible constructor for NBench 0.1.6 and earlier.
+        /// </summary>
+        /// <param name="settings">The settings for this benchmark.</param>
+        /// <param name="invoker">The invoker used to execute benchmark and setup / cleanup methods.</param>
+        /// <param name="writer">The output target this benchmark will write to.</param>
+        /// <remarks>Uses the <see cref="DefaultBenchmarkAssertionRunner"/> to assert benchmark data.</remarks>
+        public Benchmark(BenchmarkSettings settings, IBenchmarkInvoker invoker, IBenchmarkOutput writer) 
+            : this(settings, invoker, writer, DefaultBenchmarkAssertionRunner.Instance) { }
+
+        /// <summary>
+        /// Backwards-compatible constructor for NBench 0.1.6 and earlier.
+        /// </summary>
+        /// <param name="settings">The settings for this benchmark.</param>
+        /// <param name="invoker">The invoker used to execute benchmark and setup / cleanup methods.</param>
+        /// <param name="writer">The output target this benchmark will write to.</param>
+        /// <param name="benchmarkAssertions">The assertion engine we'll use to perform BenchmarkAssertions against benchmarks.</param>
+        public Benchmark(BenchmarkSettings settings, IBenchmarkInvoker invoker, IBenchmarkOutput writer, IBenchmarkAssertionRunner benchmarkAssertions)
         {
             Settings = settings;
             _pendingIterations = Settings.NumberOfIterations;
@@ -44,6 +61,7 @@ namespace NBench.Sdk
             Output = writer;
             CompletedRuns = new Queue<BenchmarkRunReport>(Settings.NumberOfIterations);
             Builder = new BenchmarkBuilder(Settings);
+            BenchmarkAssertionRunner = benchmarkAssertions;
         }
 
         public RunMode RunMode => Settings.RunMode;
@@ -52,9 +70,10 @@ namespace NBench.Sdk
         public bool ShutdownCalled { get; private set; }
         protected IBenchmarkInvoker Invoker { get; }
         protected IBenchmarkOutput Output { get; }
+        protected IBenchmarkAssertionRunner BenchmarkAssertionRunner { get; }
 
         /// <summary>
-        /// Returns <c>true</c> if <see cref="Finish"/> was called and all assertions passed,
+        /// Returns <c>true</c> if <see cref="Finish"/> was called and all BenchmarkAssertions passed,
         /// or if it was never called.
         /// </summary>
         public bool AllAssertsPassed { get; private set; }
@@ -289,7 +308,7 @@ namespace NBench.Sdk
 
         public BenchmarkFinalResults AssertResults(BenchmarkResults result)
         {
-            var assertionResults = AssertionRunner.RunAssertions(Settings, result);
+            var assertionResults = BenchmarkAssertionRunner.RunAssertions(Settings, result);
             return new BenchmarkFinalResults(result, assertionResults);
         }
 

--- a/src/NBench/Sdk/BenchmarkSettings.cs
+++ b/src/NBench/Sdk/BenchmarkSettings.cs
@@ -59,8 +59,8 @@ namespace NBench.Sdk
             // screen line for line duplicates that made it in by accident
             Measurements = new HashSet<IBenchmarkSetting>(benchmarkSettings).ToList();
 
-            // now filter terms that measure the same quantities, but with different assertions
-            // because we only want to collect those measurements ONCE, but use them across mulitple assertions.
+            // now filter terms that measure the same quantities, but with different BenchmarkAssertions
+            // because we only want to collect those measurements ONCE, but use them across mulitple BenchmarkAssertions.
             DistinctMeasurements = Measurements.Distinct(Comparer).ToList();
 
             Collectors = collectors;
@@ -94,7 +94,7 @@ namespace NBench.Sdk
         public IReadOnlyList<IBenchmarkSetting> Measurements { get; private set; }
 
         /// <summary>
-        /// If someone declares two measurements that measure the same thing, but carry different assertions
+        /// If someone declares two measurements that measure the same thing, but carry different BenchmarkAssertions
         /// then those settings will only show up once on this list, whereas they might appear twice on <see cref="Measurements"/>
         /// </summary>
         public IReadOnlyList<IBenchmarkSetting> DistinctMeasurements { get; private set; }

--- a/src/NBench/Sdk/Compiler/IDiscovery.cs
+++ b/src/NBench/Sdk/Compiler/IDiscovery.cs
@@ -20,6 +20,11 @@ namespace NBench.Sdk.Compiler
         IBenchmarkOutput Output { get; }
 
         /// <summary>
+        /// Engine used to perform BenchmarkAssertions against data collected from a <see cref="Benchmark"/>
+        /// </summary>
+        IBenchmarkAssertionRunner BenchmarkAssertions { get; }
+
+        /// <summary>
         /// Uses reflection on the target assembly to discover <see cref="PerfBenchmarkAttribute"/>
         /// instances.
         /// </summary>

--- a/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
+++ b/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
@@ -21,11 +21,16 @@ namespace NBench.Sdk.Compiler
         public static readonly Type PerformanceBenchmarkAttributeType = typeof (PerfBenchmarkAttribute);
         public static readonly Type MeasurementAttributeType = typeof (MeasurementAttribute);
         public static readonly Type BenchmarkContextType = typeof (BenchmarkContext);
-       
 
-        public ReflectionDiscovery(IBenchmarkOutput output)
+        public ReflectionDiscovery(IBenchmarkOutput output) : this(output, DefaultBenchmarkAssertionRunner.Instance)
+        {
+        }
+
+
+        public ReflectionDiscovery(IBenchmarkOutput output, IBenchmarkAssertionRunner benchmarkAssertions)
         {
             Output = _reflectionOutput = output;
+            BenchmarkAssertions = benchmarkAssertions;
         }
 
         /// <summary>
@@ -39,6 +44,7 @@ namespace NBench.Sdk.Compiler
         private static IBenchmarkOutput _reflectionOutput = new ConsoleBenchmarkOutput();
 
         public IBenchmarkOutput Output { get; }
+        public IBenchmarkAssertionRunner BenchmarkAssertions { get; }
 
         public IEnumerable<Benchmark> FindBenchmarks(Assembly targetAssembly)
         {
@@ -48,7 +54,7 @@ namespace NBench.Sdk.Compiler
             {
                 var invoker = CreateInvokerForBenchmark(data);
                 var settings = CreateSettingsForBenchmark(data);
-                benchmarks.Add(new Benchmark(settings, invoker, Output));
+                benchmarks.Add(new Benchmark(settings, invoker, Output, BenchmarkAssertions));
             }
             return benchmarks;
         }
@@ -61,7 +67,7 @@ namespace NBench.Sdk.Compiler
             {
                 var invoker = CreateInvokerForBenchmark(data);
                 var settings = CreateSettingsForBenchmark(data);
-                benchmarks.Add(new Benchmark(settings, invoker, Output));
+                benchmarks.Add(new Benchmark(settings, invoker, Output, BenchmarkAssertions));
             }
             return benchmarks;
         }

--- a/src/NBench/Sdk/DefaultBenchmarkAssertionRunner.cs
+++ b/src/NBench/Sdk/DefaultBenchmarkAssertionRunner.cs
@@ -11,20 +11,24 @@ namespace NBench.Sdk
     /// <summary>
     ///     Responsible for running <see cref="Assertion" />s over <see cref="BenchmarkResults" />.
     /// </summary>
-    public static class AssertionRunner
+    public class DefaultBenchmarkAssertionRunner : IBenchmarkAssertionRunner
     {
-        public static IReadOnlyList<AssertionResult> RunAssertions(BenchmarkSettings settings, BenchmarkResults results)
+        public static readonly DefaultBenchmarkAssertionRunner Instance = new DefaultBenchmarkAssertionRunner();
+
+        private DefaultBenchmarkAssertionRunner() { }
+
+        public IReadOnlyList<AssertionResult> RunAssertions(BenchmarkSettings settings, BenchmarkResults results)
         {
             Contract.Requires(settings != null);
             var assertionResults = new List<AssertionResult>();
 
-            // Not in testing mode, therefore we don't need to apply these assertions
+            // Not in testing mode, therefore we don't need to apply these BenchmarkAssertions
             if (settings.TestMode == TestMode.Measurement)
             {
                 return assertionResults;
             }
 
-            // collect all benchmark settings with non-empty assertions
+            // collect all benchmark settings with non-empty BenchmarkAssertions
             IReadOnlyList<IBenchmarkSetting> allSettings = settings.Measurements.Where(x => !x.Assertion.Equals(Assertion.Empty)).ToList();
 
             foreach (var setting in allSettings)

--- a/src/NBench/Sdk/IBenchmarkAssertionRunner.cs
+++ b/src/NBench/Sdk/IBenchmarkAssertionRunner.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using NBench.Reporting;
+
+namespace NBench.Sdk
+{
+    /// <summary>
+    /// Responsible for running <see cref="Assertion" />s over <see cref="BenchmarkResults" />.
+    /// </summary>
+    public interface IBenchmarkAssertionRunner
+    {
+        /// <summary>
+        /// Based on the provided <see cref="BenchmarkSettings"/> and the <see cref="BenchmarkResults"/>
+        /// collected from running a <see cref="Benchmark"/>, determine if all of the configured BenchmarkAssertions
+        /// pass or not.
+        /// </summary>
+        /// <param name="settings">The settings for this benchmark.</param>
+        /// <param name="results">The results from this benchmark.</param>
+        /// <returns>A set of individual <see cref="AssertionResult"/> instances.</returns>
+        IReadOnlyList<AssertionResult> RunAssertions(BenchmarkSettings settings, BenchmarkResults results);
+    }
+}

--- a/tests/NBench.Tests.End2End/SampleBenchmarks/GcAllGenerationsAssertionBenchmark.cs
+++ b/tests/NBench.Tests.End2End/SampleBenchmarks/GcAllGenerationsAssertionBenchmark.cs
@@ -5,7 +5,7 @@ namespace NBench.Tests.End2End.SampleBenchmarks
 {
     public class GcAllGenerationsAssertionBenchmark
     {
-        [PerfBenchmark(Description = "Verifier for GC.AllGenerations assertions", RunMode = RunMode.Iterations, TestMode = TestMode.Test,
+        [PerfBenchmark(Description = "Verifier for GC.AllGenerations BenchmarkAssertions", RunMode = RunMode.Iterations, TestMode = TestMode.Test,
             RunTimeMilliseconds = 1000, NumberOfIterations = 30)]
         [GcThroughputAssertion(GcMetric.TotalCollections, GcGeneration.AllGc, MustBe.ExactlyEqualTo, 0.0d)]
         public void ShouldNotGc()

--- a/tests/NBench.Tests.Performance/IterationModeMeasurementSpec.cs
+++ b/tests/NBench.Tests.Performance/IterationModeMeasurementSpec.cs
@@ -18,7 +18,7 @@ namespace NBench.Tests.Performance
         [PerfBenchmark(Description = "Test to ensure that the math following an iteration mode test is accurate",
             NumberOfIterations = 3, RunMode = RunMode.Iterations, RunTimeMilliseconds = 1000, TestMode = TestMode.Test)]
         [CounterTotalAssertion("Counter1", MustBe.GreaterThanOrEqualTo, 1000.0d)]
-        [CounterTotalAssertion("Counter1", MustBe.GreaterThan, 500.0d)] // duplicate, to see if multiple assertions against same counter run
+        [CounterTotalAssertion("Counter1", MustBe.GreaterThan, 500.0d)] // duplicate, to see if multiple BenchmarkAssertions against same counter run
         [CounterTotalAssertion("Counter2", MustBe.GreaterThanOrEqualTo, 1000.0d)]
         [CounterMeasurement("Counter2")]
         public void Benchmark()


### PR DESCRIPTION
added the IBenchmarkAssertionRunner interface, which allows us to make the underlying assertion system extensible and pluggable via arguments provided to `ReflectionDiscovery`. Should make #85 possible to do going forward.