### PR TITLE
New class NBench.SysInfo.Windows.WmiSysInfo to show CPU metadata.

### DIFF
--- a/NBench.sln
+++ b/NBench.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{C8104500-2C0F-46A2-AE84-A3D74CC55697}"
 EndProject
@@ -38,6 +38,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PeformanceCounters.Tests.End2End", "tests\NBench.PeformanceCounters.Tests.End2End\NBench.PeformanceCounters.Tests.End2End.csproj", "{416A4BAD-459C-4896-A44C-4C2344EBE154}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.PerformanceCounters.Tests.Performance", "tests\NBench.PerformanceCounters.Tests.Performance\NBench.PerformanceCounters.Tests.Performance.csproj", "{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.SysInfo.Windows.Tests", "Tests\NBench.SysInfo.Windows.Tests\NBench.SysInfo.Windows.Tests.csproj", "{121C9422-150A-44CB-BE95-7E0D77F26797}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBench.SysInfo.Windows", "src\NBench.SysInfo.Windows\NBench.SysInfo.Windows.csproj", "{853D3BF4-EBCF-46E0-8131-2813049CEDC3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +89,14 @@ Global
 		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{121C9422-150A-44CB-BE95-7E0D77F26797}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{121C9422-150A-44CB-BE95-7E0D77F26797}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{121C9422-150A-44CB-BE95-7E0D77F26797}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{121C9422-150A-44CB-BE95-7E0D77F26797}.Release|Any CPU.Build.0 = Release|Any CPU
+		{853D3BF4-EBCF-46E0-8131-2813049CEDC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{853D3BF4-EBCF-46E0-8131-2813049CEDC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{853D3BF4-EBCF-46E0-8131-2813049CEDC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{853D3BF4-EBCF-46E0-8131-2813049CEDC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,5 +109,6 @@ Global
 		{96FCB3AB-8C76-4BD0-B97F-1239E5FF5C5C} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{416A4BAD-459C-4896-A44C-4C2344EBE154} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 		{FD7BE8F5-460F-4A3D-A479-E4AF36C4EED5} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
+		{121C9422-150A-44CB-BE95-7E0D77F26797} = {1F1914B9-8F67-4B51-9738-CDE5AFB2F8DE}
 	EndGlobalSection
 EndGlobal

--- a/src/NBench.SysInfo.Windows/ISysInfo.cs
+++ b/src/NBench.SysInfo.Windows/ISysInfo.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace NBench.SysInfo.Windows
+namespace NBench.Sys
 {
     public interface ISysInfo
     {

--- a/src/NBench.SysInfo.Windows/ISysInfo.cs
+++ b/src/NBench.SysInfo.Windows/ISysInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace NBench.SysInfo.Windows
+{
+    public interface ISysInfo
+    {
+        void LoadSysInfo(IDictionary<string, string> info);
+    }
+}

--- a/src/NBench.SysInfo.Windows/NBench.SysInfo.Windows.csproj
+++ b/src/NBench.SysInfo.Windows/NBench.SysInfo.Windows.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{853D3BF4-EBCF-46E0-8131-2813049CEDC3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NBench.SysInfo.Windows</RootNamespace>
+    <AssemblyName>NBench.SysInfo.Windows</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ISysInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WmiSysInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NBench.SysInfo.Windows/NBench.SysInfo.Windows.csproj
+++ b/src/NBench.SysInfo.Windows/NBench.SysInfo.Windows.csproj
@@ -43,6 +43,9 @@
   <ItemGroup>
     <Compile Include="ISysInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WmiBiosSysInfo.cs" />
+    <Compile Include="WmiPhysicalMemorySysInfo.cs" />
+    <Compile Include="WmiProcessorSysInfo.cs" />
     <Compile Include="WmiSysInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NBench.SysInfo.Windows/Properties/AssemblyInfo.cs
+++ b/src/NBench.SysInfo.Windows/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NBench.SysInfo.Windows")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NBench.SysInfo.Windows")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("853d3bf4-ebcf-46e0-8131-2813049cedc3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NBench.SysInfo.Windows/WmiBiosSysInfo.cs
+++ b/src/NBench.SysInfo.Windows/WmiBiosSysInfo.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using NBench.Sys;
+using System.Management;
+
+namespace NBench.SysInfo.Windows
+{
+    /// <summary>
+    /// Obtain BIOS information using Windows Management Instrumentation (WMI).
+    /// </summary>
+    /// <remarks>
+    /// Explore the available properties using PowerShell:
+    /// Get-WmiObject -Class Win32_BIOS
+    /// </remarks>
+    public class WmiBiosSysInfo : WmiSysInfo, ISysInfo
+    {
+        public WmiBiosSysInfo()
+            : base("SELECT * FROM Win32_BIOS")
+        {
+        }
+
+        protected override string GetKeyPrefix(ManagementBaseObject bios)
+        {
+            return "BIOS|";
+        }
+    }
+}

--- a/src/NBench.SysInfo.Windows/WmiPhysicalMemorySysInfo.cs
+++ b/src/NBench.SysInfo.Windows/WmiPhysicalMemorySysInfo.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using NBench.Sys;
+using System.Management;
+
+namespace NBench.SysInfo.Windows
+{
+    /// <summary>
+    /// Obtain Physical Memory (RAM) information using Windows Management Instrumentation (WMI).
+    /// </summary>
+    /// <remarks>
+    /// Explore the available properties using PowerShell:
+    /// Get-WmiObject -Class Win32_PhysicalMemory
+    /// </remarks>
+    public sealed class WmiPhysicalMemorySysInfo : WmiSysInfo, ISysInfo
+    {
+        public WmiPhysicalMemorySysInfo()
+            : base("SELECT * FROM Win32_PhysicalMemory")
+        {
+        }
+
+        protected override string GetKeyPrefix(ManagementBaseObject memoryUnit)
+        {
+            return string.Format("RAM {0}|", memoryUnit["DeviceLocator"]);
+        }
+    }
+}

--- a/src/NBench.SysInfo.Windows/WmiProcessorSysInfo.cs
+++ b/src/NBench.SysInfo.Windows/WmiProcessorSysInfo.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using NBench.Sys;
+using System.Management;
+
+namespace NBench.SysInfo.Windows
+{
+    /// <summary>
+    /// Obtain Processor (CPU) information using Windows Management Instrumentation (WMI).
+    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394104(v=vs.85).aspx"/>
+    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394373(v=vs.85).aspx"/>
+    /// </summary>
+    /// <remarks>
+    /// Explore the available properties using PowerShell:
+    /// Get-WmiObject -Class Win32_ComputerSystemProcessor
+    /// Get-WmiObject -Class Win32_Processor
+    /// </remarks>
+    public sealed class WmiProcessorSysInfo : WmiSysInfo, ISysInfo
+    {
+        public WmiProcessorSysInfo()
+            : base("SELECT * FROM Win32_Processor")
+        {
+        }
+
+        protected override string GetKeyPrefix(ManagementBaseObject processor)
+        {
+            return string.Format("{0}|", processor["DeviceID"]);
+        }
+    }
+}

--- a/src/NBench.SysInfo.Windows/WmiSysInfo.cs
+++ b/src/NBench.SysInfo.Windows/WmiSysInfo.cs
@@ -1,64 +1,39 @@
 ﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 
-using System;
+using NBench.Sys;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management;
-using System.Text;
 
 namespace NBench.SysInfo.Windows
 {
     /// <summary>
-    /// Obtain Processor (CPU) information using Windows Management Instrumentation (WMI).
-    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394104(v=vs.85).aspx"/>
-    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394373(v=vs.85).aspx"/>
+    /// Query Method for Windows Management Instrumentation (WMI).
     /// </summary>
-    /// <remarks>
-    /// Explore the available properties using PowerShell:
-    /// Get-WmiObject -Class Win32_ComputerSystemProcessor
-    /// Get-WmiObject -Class Win32_Processor
-    /// </remarks>
-    public sealed class WmiSysInfo : ISysInfo
+    public abstract class WmiSysInfo : ISysInfo
     {
         private readonly ManagementScope _managementScope;
         private readonly SelectQuery _wmiQuery;
 
-        public WmiSysInfo()
+        protected WmiSysInfo(string wmiSelect)
         {
             var wmiPath = @"\\localhost\root\cimv2";
             _managementScope = new ManagementScope(wmiPath);
 
-            var wmiSelect = "SELECT * FROM Win32_Processor";
             _wmiQuery = new SelectQuery(wmiSelect);
         }
 
-        public void LoadSysInfo(IDictionary<string, string> info)
+        protected abstract string GetKeyPrefix(ManagementBaseObject mbo);
+
+        protected virtual string GetKeyName(string keyPrefix, PropertyData pd)
         {
-            if (info == null)
-                return;
-
-            using (var searcher = new ManagementObjectSearcher(_managementScope, _wmiQuery))
-            {
-                var processorList = searcher.Get();
-
-                foreach (var processor in processorList)
-                {
-                    var keyPrefix = string.Format("{0}|", processor["DeviceID"]);
-
-                    foreach (var processorProperty in processor.Properties)
-                    {
-                        if (IsReportable(processorProperty))
-                        {
-                            var keyName = keyPrefix + processorProperty.Name;
-                            info.Add(keyName, processorProperty.Value.ToString());
-                        }
-                    }
-                }
-            }
+            return keyPrefix + pd.Name;
         }
-
-        private static bool IsReportable(PropertyData processorProperty)
+        protected virtual string GetValueString(PropertyData pd)
+        {
+            return (pd.Value == null) ? string.Empty : pd.Value.ToString();
+        }
+        protected virtual bool IsReportable(PropertyData processorProperty)
         {
             bool mustInclude = true;
 
@@ -70,6 +45,32 @@ namespace NBench.SysInfo.Windows
             mustInclude = mustInclude && !string.IsNullOrWhiteSpace(processorProperty.Value.ToString());
 
             return mustInclude;
+        }
+        public void LoadSysInfo(IDictionary<string, string> info)
+        {
+            if (info == null)
+                return;
+
+            using (var searcher = new ManagementObjectSearcher(_managementScope, _wmiQuery))
+            {
+                var wmiSearchResults = searcher.Get();
+
+                foreach (var wmiInfo in wmiSearchResults)
+                {
+                    var keyPrefix = GetKeyPrefix(wmiInfo);
+
+                    foreach (var wmiProperty in wmiInfo.Properties)
+                    {
+                        var keyName = GetKeyName(keyPrefix, wmiProperty);
+
+                        if (IsReportable(wmiProperty) &&
+                            !info.ContainsKey(keyName))
+                        {
+                            info.Add(keyName, GetValueString(wmiProperty));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/NBench.SysInfo.Windows/WmiSysInfo.cs
+++ b/src/NBench.SysInfo.Windows/WmiSysInfo.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+using System.Text;
+
+namespace NBench.SysInfo.Windows
+{
+    /// <summary>
+    /// Obtain Processor (CPU) information using Windows Management Instrumentation (WMI).
+    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394104(v=vs.85).aspx"/>
+    /// <seealso cref="https://msdn.microsoft.com/en-us/library/aa394373(v=vs.85).aspx"/>
+    /// </summary>
+    /// <remarks>
+    /// Explore the available properties using PowerShell:
+    /// Get-WmiObject -Class Win32_ComputerSystemProcessor
+    /// Get-WmiObject -Class Win32_Processor
+    /// </remarks>
+    public sealed class WmiSysInfo : ISysInfo
+    {
+        private readonly ManagementScope _managementScope;
+        private readonly SelectQuery _wmiQuery;
+
+        public WmiSysInfo()
+        {
+            var wmiPath = @"\\localhost\root\cimv2";
+            _managementScope = new ManagementScope(wmiPath);
+
+            var wmiSelect = "SELECT * FROM Win32_Processor";
+            _wmiQuery = new SelectQuery(wmiSelect);
+        }
+
+        public void LoadSysInfo(IDictionary<string, string> info)
+        {
+            if (info == null)
+                return;
+
+            using (var searcher = new ManagementObjectSearcher(_managementScope, _wmiQuery))
+            {
+                var processorList = searcher.Get();
+
+                foreach (var processor in processorList)
+                {
+                    var keyPrefix = string.Format("{0}|", processor["DeviceID"]);
+
+                    foreach (var processorProperty in processor.Properties)
+                    {
+                        if (IsReportable(processorProperty))
+                        {
+                            var keyName = keyPrefix + processorProperty.Name;
+                            info.Add(keyName, processorProperty.Value.ToString());
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool IsReportable(PropertyData processorProperty)
+        {
+            bool mustInclude = true;
+
+            mustInclude = mustInclude && !processorProperty.IsArray;
+
+            mustInclude = mustInclude && !processorProperty.Name.StartsWith("__");
+
+            mustInclude = mustInclude && (processorProperty.Value != null);
+            mustInclude = mustInclude && !string.IsNullOrWhiteSpace(processorProperty.Value.ToString());
+
+            return mustInclude;
+        }
+    }
+}

--- a/tests/NBench.SysInfo.Windows.Tests/NBench.SysInfo.Windows.Tests.WmiSysInfoSpec.cs
+++ b/tests/NBench.SysInfo.Windows.Tests/NBench.SysInfo.Windows.Tests.WmiSysInfoSpec.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace NBench.SysInfo.Windows.Tests
+{
+    public class WmiSysInfoSpec
+    {
+        [Fact]
+        public void LoadWmiSysInfo()
+        {
+            var info = new SortedDictionary<string, string>();
+
+            var wmiSysInfo = new NBench.SysInfo.Windows.WmiSysInfo();
+            wmiSysInfo.LoadSysInfo(info);
+
+            Assert.NotEmpty(info);
+
+            Debug.WriteLine(string.Empty.PadLeft(25, '=') + " Win32_Processor:");
+            foreach (var key in info.Keys)
+            {
+                Debug.WriteLine(string.Format(" {0}: {1}", key, info[key]));
+            }
+            Debug.WriteLine(string.Empty.PadLeft(25, '=') + " Win32_Processor (END)");
+        }
+    }
+}

--- a/tests/NBench.SysInfo.Windows.Tests/NBench.SysInfo.Windows.Tests.csproj
+++ b/tests/NBench.SysInfo.Windows.Tests/NBench.SysInfo.Windows.Tests.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{121C9422-150A-44CB-BE95-7E0D77F26797}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NBench.SysInfo.Windows.Tests</RootNamespace>
+    <AssemblyName>NBench.SysInfo.Windows.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NBench.SysInfo.Windows.Tests.WmiSysInfoSpec.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NBench.SysInfo.Windows\NBench.SysInfo.Windows.csproj">
+      <Project>{853d3bf4-ebcf-46e0-8131-2813049cedc3}</Project>
+      <Name>NBench.SysInfo.Windows</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/NBench.SysInfo.Windows.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NBench.SysInfo.Windows.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Petabridge <https://petabridge.com/>. All rights reserved.
+// Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NBench.SysInfo.Windows.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NBench.SysInfo.Windows.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("121c9422-150a-44cb-be95-7e0d77f26797")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NBench.SysInfo.Windows.Tests/packages.config
+++ b/tests/NBench.SysInfo.Windows.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Not integrated with NBench. This is a stand-alone assembly as an example for #107.

The new interface ISysInfo must move to a common assembly.
See class WmiSysInfoSpec for a unit test writing sample output.
