### PR TITLE
added v0.2.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-#### 0.2.2 March 22 2016
-Placeholder for vNext
+#### 0.2.2 May 03 2016
+Warmup count is now equal to iteration count on all benchmarks, useful for users with long-running macro benchmarks and stress tests.
 
 #### 0.2.1 March 22 2016
 Fixed issue with NuGet logos and concurrency settings - we now still keep the process priority set to high, as we did before.


### PR DESCRIPTION
#### 0.2.2 May 03 2016
Warmup count is now equal to iteration count on all benchmarks, useful for users with long-running macro benchmarks and stress tests.
