### PR TITLE
disabled foreground thread prioritization for NBench concurrent mode

### DIFF
--- a/src/NBench/Sdk/TestRunner.cs
+++ b/src/NBench/Sdk/TestRunner.cs
@@ -93,7 +93,15 @@ namespace NBench.Sdk
              * Set priority
              */
             Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
-            Thread.CurrentThread.Priority = ThreadPriority.Highest;
+            if (!concurrent)
+            {
+                /*
+                 * If we're running in concurrent mode, don't give the foreground thread higher priority
+                 * over the other threads participating in NBench specs. Treat them all equally with the same
+                 * priority.
+                 */
+                Thread.CurrentThread.Priority = ThreadPriority.Highest;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I explain my reasoning for this change in the comment on the code itself. I'll call it out on the PR.