### PR TITLE
minor cleanup and NBench 0.3.0 release notes + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The test is executed on the complete name of the benchmark `Namespace.Class+Meth
 * **exclude=name test pattern** - a "`,`"(comma) separted list of wildcard pattern to be mached and excluded in the tests. Default value is `` (none)
 The test is executed on the complete name of the benchmark `Namespace.Class+MethodName`
 * **concurrent=true|false** - disables thread priority and processor affinity operations for all benchmarks. Used only when running multi-threaded benchmarks. Set to `false` (single-threaded) by default.
+* **tracing=true|false** - turns on trace capture inside the NBench runner and will save any captured messages to all available output targets, including Markdown reports. Set to `false` by default.
 
 Supported wildcard patterns are `*` any string and `?` any char. In order to include a class with all its tests in the benchmark
 you need to specify a pattern finishing in `*`. E.g. `include=*.MyBenchmarkClass.*`.
@@ -89,6 +90,7 @@ Here are the different options for creating a `PerfBenchmark`:
 * `TestMode` - sets the test mode for this benchmark. Possible options are `TestMode.Measurement` and `TestMode.Test`. More on what those options mean in a moment.
 * `NumberOfIterations` - determines how many times this benchmark will be run. All final benchmark statistics are reported as an aggregate across all iterations.
 * `RunTimeMilliseconds` - for `RunMode.ThroughPut`, this indicates how long we'll attempt to run a test for in order to measure the metric per second values.
+* `SkipWarmups` - disables "warmup" iterations that are used to perform cache warming on the CPU. Disabling warmups is often used in long-running iteration tests.
 
 You can declare a `PerfBenchmark` attribute on multiple methods within a single POCO class and each one will be run as its own independent benchmark.
 

--- a/src/NBench/Reporting/Targets/MarkdownBenchmarkOutput.cs
+++ b/src/NBench/Reporting/Targets/MarkdownBenchmarkOutput.cs
@@ -88,8 +88,8 @@ namespace NBench.Reporting.Targets
             }
             sb.AppendLine(
                 $"NumberOfIterations={results.Data.Settings.NumberOfIterations}, MaximumRunTime={results.Data.Settings.RunTime}");
-            sb.AppendLine($"Concurrency Mode Enabled={results.Data.Settings.ConcurrentMode}");
-            sb.AppendLine($"Tracing Enabled={results.Data.Settings.TracingEnabled}");
+            sb.AppendLine($"Concurrent={results.Data.Settings.ConcurrentMode}");
+            sb.AppendLine($"Tracing={results.Data.Settings.TracingEnabled}");
             sb.AppendLine("```");
             sb.AppendLine();
             sb.AppendLine("## Data");


### PR DESCRIPTION
#### 0.3.0 May 24 2016
This release introduces some breaking changes to NBench:

**Tracing**
The biggest feature included in this release is the addition of tracing support, which is exposed directly to end-users so they can capture trace events and include them in the output produced by NBench.

You can access the `IBenchmarkTrace` object through the `BenchmarkContext` passed into any of your `PerfSetup`, `PerfBenchmark`, or `PerfCleanup` methods like such:

```csharp
public class TracingBenchmark
{
   
    [PerfSetup]
    public void Setup(BenchmarkContext context)
    {
        context.Trace.Debug(SetupTrace);
    }

    [PerfBenchmark(TestMode = TestMode.Test, NumberOfIterations = IterationCount, RunTimeMilliseconds = 1000)]
    [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
    [MemoryAssertion(MemoryMetric.TotalBytesAllocated, MustBe.LessThan, ByteConstants.EightKb)]
    public void Run1(BenchmarkContext context)
    {
        context.Trace.Debug(RunTrace);
    }

    [PerfCleanup]
    public void Cleanup(BenchmarkContext context)
    {
        context.Trace.Info(CleanupTrace);
    }
}
```

`NBench.Runner.exe` now takes a `trace=true|false` commandline argument, which will enable the new tracing feature introduced in this release.

**Tracing is disabled by default**.

**Skippable Warmups**
You can now elect to skip warmups altogether for your specs. This feature is particularly useful for long-running iteration benchmarks, which are often used for stress tests. Warmups don't add any value here.

Here's how you can skip warmups:

```csharp
[PerfBenchmark(TestMode = TestMode.Test, NumberOfIterations = IterationCount, RunTimeMilliseconds = 1000, SkipWarmups = true)]
[MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
[MemoryAssertion(MemoryMetric.TotalBytesAllocated, MustBe.LessThan, ByteConstants.EightKb)]
public void Run1(BenchmarkContext context)
{
    context.Trace.Debug(RunTrace);
}
```

Just set `SkipWarmups = true` on your `PerfBenchmark` attribute wherever you wish to skip a warmup.

**Foreground thread is no longer given high priority when concurrent mode is on**.

If you are running the `NBench.Runner` with `concurrent=true`, we no longer give the main foreground thread high priority as this resulted in some unfair scheduling during concurrent tests. All threads within the `NBench.Runner` process all share the same priority now.

**Markdown reports include additional data**
All markdown reports now include:

* The concurrency setting for NBench
* The tracing setting for NBench
* A flag indicating if warmups were skipped or not

All of these were added in order to make it easy for end-users reading the reports to know what the NBench settings were at the time the report was produced.