### PR TITLE
Enable .NET Core clients to use NBench.Runner.DotNetCli via .csproj file DotNetCliToolReference

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -153,7 +153,7 @@ Target "NBench" <| fun _ ->
             info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
-    let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/NBench.Runner.DotNetCli.dll"
+    let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/dotnet-nbench.dll"
     let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
     DotNetCli.RunCommand
         (fun p ->

--- a/build.fsx
+++ b/build.fsx
@@ -153,7 +153,16 @@ Target "NBench" <| fun _ ->
             info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
-    let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/dotnet-nbench.dll"
+    let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
+    // build a win7-x64 version of dotnet-nbench.dll so we know we're testing the same architecture
+    DotNetCli.Build
+        (fun p -> 
+            { p with
+                Project = netCoreNbenchRunnerProject
+                Configuration = configuration 
+                Runtime = "win7-x64" })   
+
+    let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/dotnet-nbench.dll"
     let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
     DotNetCli.RunCommand
         (fun p ->

--- a/build.fsx
+++ b/build.fsx
@@ -153,22 +153,22 @@ Target "NBench" <| fun _ ->
             info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
-    let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
-    // build a win7-x64 version of dotnet-nbench.dll so we know we're testing the same architecture
-    DotNetCli.Build
-        (fun p -> 
-            { p with
-                Project = netCoreNbenchRunnerProject
-                Configuration = configuration 
-                Runtime = "win7-x64" })   
+        let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
+        // build a win7-x64 version of dotnet-nbench.dll so we know we're testing the same architecture
+        DotNetCli.Build
+            (fun p -> 
+                { p with
+                    Project = netCoreNbenchRunnerProject
+                    Configuration = configuration 
+                    Runtime = "win7-x64" })   
 
-    let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/dotnet-nbench.dll"
-    let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
-    DotNetCli.RunCommand
-        (fun p ->
-            { p with
-                TimeOut = TimeSpan.FromMinutes 25.0 })
-        (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunner netCoreAssembly outputPerfTests true true)
+        let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/dotnet-nbench.dll"
+        let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
+        DotNetCli.RunCommand
+            (fun p ->
+                { p with
+                    TimeOut = TimeSpan.FromMinutes 25.0 })
+            (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunner netCoreAssembly outputPerfTests true true)
 
 Target "CopyOutput" (fun _ ->    
     // .NET 4.5

--- a/build.fsx
+++ b/build.fsx
@@ -135,6 +135,7 @@ Target "RunTests" (fun _ ->
 
 Target "NBench" <| fun _ ->
     if (isWindows) then
+        // .NET 4.5.2
         let nbenchRunner = findToolInSubPath "NBench.Runner.exe" "tools/NBench.Runner/lib/net45"
         let assembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/net452/NBench.Tests.Performance.dll"
         
@@ -153,6 +154,7 @@ Target "NBench" <| fun _ ->
             info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchRunner args
     
+        // .NET Core
         let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
         DotNetCli.Restore
             (fun p ->
@@ -184,13 +186,37 @@ Target "NBench" <| fun _ ->
             info.Arguments <- netCoreNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" netCoreNbenchRunner netCoreNbenchRunnerArgs
     else
-        let netCoreNbenchRunnerLinux = "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/dotnet-nbench.dll"
-        let netCoreAssemblyLinux = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
-        DotNetCli.RunCommand
+        // .NET Core
+        let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
+        DotNetCli.Restore
             (fun p ->
                 { p with
-                    TimeOut = TimeSpan.FromMinutes 25.0 })
-            (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunnerLinux netCoreAssemblyLinux outputPerfTests true true)
+                    Project = netCoreNbenchRunnerProject
+                    AdditionalArgs = ["-r debian.8-x64"] })
+        // build a win7-x64 version of dotnet-nbench.dll so we know we're testing the same architecture
+        DotNetCli.Build
+            (fun p -> 
+                { p with
+                    Project = netCoreNbenchRunnerProject
+                    Configuration = configuration 
+                    Runtime = "debian.8-x64"
+                    Framework = "netcoreapp1.0"})   
+        
+        let linuxNbenchRunner =  __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/debian.8-x64/dotnet-nbench"
+        let linuxPerfAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
+        
+        let linuxNbenchRunnerArgs = new StringBuilder()
+                                        |> append linuxPerfAssembly
+                                        |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
+                                        |> append (sprintf "concurrent=\"%b\"" true)
+                                        |> append (sprintf "trace=\"%b\"" true)
+                                        |> toText
+
+        let result = ExecProcess(fun info -> 
+            info.FileName <- linuxNbenchRunner
+            info.WorkingDirectory <- __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/debian.8-x64/"
+            info.Arguments <- linuxNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
+        if result <> 0 then failwithf "NBench.Runner failed. %s %s" linuxNbenchRunner linuxNbenchRunnerArgs
 
 Target "CopyOutput" (fun _ ->    
     // .NET 4.5

--- a/build.fsx
+++ b/build.fsx
@@ -135,23 +135,23 @@ Target "RunTests" (fun _ ->
 
 Target "NBench" <| fun _ ->
     if (isWindows) then
-        //let nbenchRunner = findToolInSubPath "NBench.Runner.exe" "tools/NBench.Runner/lib/net45"
-        //let assembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/net452/NBench.Tests.Performance.dll"
+        let nbenchRunner = findToolInSubPath "NBench.Runner.exe" "tools/NBench.Runner/lib/net45"
+        let assembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/net452/NBench.Tests.Performance.dll"
         
-        //let spec = getBuildParam "spec"
+        let spec = getBuildParam "spec"
 
-        //let args = new StringBuilder()
-        //            |> append assembly
-        //            |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
-        //            |> append (sprintf "concurrent=\"%b\"" true)
-        //            |> append (sprintf "trace=\"%b\"" true)
-        //            |> toText
+        let args = new StringBuilder()
+                    |> append assembly
+                    |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
+                    |> append (sprintf "concurrent=\"%b\"" true)
+                    |> append (sprintf "trace=\"%b\"" true)
+                    |> toText
 
-        //let result = ExecProcess(fun info -> 
-        //    info.FileName <- nbenchRunner
-        //    info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchRunner))
-        //    info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
-        //if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchRunner args
+        let result = ExecProcess(fun info -> 
+            info.FileName <- nbenchRunner
+            info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchRunner))
+            info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
+        if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchRunner args
     
         let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
         DotNetCli.Restore
@@ -184,7 +184,7 @@ Target "NBench" <| fun _ ->
             info.Arguments <- netCoreNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" netCoreNbenchRunner netCoreNbenchRunnerArgs
     else
-        let netCoreNbenchRunnerLinux = findToolInSubPath "dotnet-nbench.exe" "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/"
+        let netCoreNbenchRunnerLinux = "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/dotnet-nbench.dll"
         let netCoreAssemblyLinux = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
         DotNetCli.RunCommand
             (fun p ->

--- a/build.fsx
+++ b/build.fsx
@@ -171,12 +171,6 @@ Target "NBench" <| fun _ ->
         let netCoreNbenchRunner = findToolInSubPath "dotnet-nbench.exe" "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/"
         let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
         
-        //DotNetCli.RunCommand
-        //    (fun p ->
-        //        { p with
-        //            TimeOut = TimeSpan.FromMinutes 25.0 })
-        //    (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunner netCoreAssembly outputPerfTests true true)
-
         let netCoreNbenchRunnerArgs = new StringBuilder()
                                         |> append netCoreAssembly
                                         |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
@@ -189,6 +183,14 @@ Target "NBench" <| fun _ ->
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName netCoreNbenchRunner))
             info.Arguments <- netCoreNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" netCoreNbenchRunner netCoreNbenchRunnerArgs
+    else
+        let netCoreNbenchRunnerLinux = findToolInSubPath "dotnet-nbench.exe" "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/"
+        let netCoreAssemblyLinux = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
+        DotNetCli.RunCommand
+            (fun p ->
+                { p with
+                    TimeOut = TimeSpan.FromMinutes 25.0 })
+            (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunnerLinux netCoreAssemblyLinux outputPerfTests true true)
 
 Target "CopyOutput" (fun _ ->    
     // .NET 4.5

--- a/build.fsx
+++ b/build.fsx
@@ -160,7 +160,8 @@ Target "NBench" <| fun _ ->
                 { p with
                     Project = netCoreNbenchRunnerProject
                     Configuration = configuration 
-                    Runtime = "win7-x64" })   
+                    Runtime = "win7-x64"
+                    Framework = "netcoreapp1.0"})   
 
         let netCoreNbenchRunner = __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/dotnet-nbench.dll"
         let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"

--- a/build.fsx
+++ b/build.fsx
@@ -210,8 +210,7 @@ Target "CreateNuget" (fun _ ->
                     Project = proj
                     Configuration = configuration
                     AdditionalArgs = ["--include-symbols"]
-                    OutputPath = outputNuGet
-                    VersionSuffix = version })
+                    OutputPath = outputNuGet })
         )
 )
 

--- a/build.fsx
+++ b/build.fsx
@@ -135,25 +135,30 @@ Target "RunTests" (fun _ ->
 
 Target "NBench" <| fun _ ->
     if (isWindows) then
-        let nbenchRunner = findToolInSubPath "NBench.Runner.exe" "tools/NBench.Runner/lib/net45"
-        let assembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/net452/NBench.Tests.Performance.dll"
+        //let nbenchRunner = findToolInSubPath "NBench.Runner.exe" "tools/NBench.Runner/lib/net45"
+        //let assembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/net452/NBench.Tests.Performance.dll"
         
-        let spec = getBuildParam "spec"
+        //let spec = getBuildParam "spec"
 
-        let args = new StringBuilder()
-                |> append assembly
-                |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
-                |> append (sprintf "concurrent=\"%b\"" true)
-                |> append (sprintf "trace=\"%b\"" true)
-                |> toText
+        //let args = new StringBuilder()
+        //            |> append assembly
+        //            |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
+        //            |> append (sprintf "concurrent=\"%b\"" true)
+        //            |> append (sprintf "trace=\"%b\"" true)
+        //            |> toText
 
-        let result = ExecProcess(fun info -> 
-            info.FileName <- nbenchRunner
-            info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchRunner))
-            info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
-        if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchRunner args
+        //let result = ExecProcess(fun info -> 
+        //    info.FileName <- nbenchRunner
+        //    info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchRunner))
+        //    info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
+        //if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchRunner args
     
         let netCoreNbenchRunnerProject = "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj"
+        DotNetCli.Restore
+            (fun p ->
+                { p with
+                    Project = netCoreNbenchRunnerProject
+                    AdditionalArgs = ["-r win7-x64"] })
         // build a win7-x64 version of dotnet-nbench.dll so we know we're testing the same architecture
         DotNetCli.Build
             (fun p -> 
@@ -172,11 +177,18 @@ Target "NBench" <| fun _ ->
         //            TimeOut = TimeSpan.FromMinutes 25.0 })
         //    (sprintf "%s %s output-directory=\"%s\" concurrent=\"%b\" trace=\"%b\"" netCoreNbenchRunner netCoreAssembly outputPerfTests true true)
 
+        let netCoreNbenchRunnerArgs = new StringBuilder()
+                                        |> append netCoreAssembly
+                                        |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
+                                        |> append (sprintf "concurrent=\"%b\"" true)
+                                        |> append (sprintf "trace=\"%b\"" true)
+                                        |> toText
+
         let result = ExecProcess(fun info -> 
             info.FileName <- netCoreNbenchRunner
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName netCoreNbenchRunner))
-            info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
-        if result <> 0 then failwithf "NBench.Runner failed. %s %s" netCoreNbenchRunner args
+            info.Arguments <- netCoreNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
+        if result <> 0 then failwithf "NBench.Runner failed. %s %s" netCoreNbenchRunner netCoreNbenchRunnerArgs
 
 Target "CopyOutput" (fun _ ->    
     // .NET 4.5

--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
 
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
-$DotNetChannel = "preview";
+$DotNetChannel = "production";
 $DotNetVersion = "1.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0";
+$DotNetVersion = "1.0.1";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
@@ -78,7 +78,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
         mkdir -Force $InstallPath | Out-Null;
     }
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
+    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath -Architecture x64;
 
     Remove-PathVariable "$InstallPath"
     $env:PATH = "$InstallPath;$env:PATH"

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0-rc4-004771";
+$DotNetVersion = "1.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"

--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
 
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
-$DotNetChannel = "production";
+$DotNetChannel = "preview";
 $DotNetVersion = "1.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 1.0.0-rc4-004771 --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 1.0.0 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
+++ b/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
@@ -10,7 +10,6 @@
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
-    <Prefer32Bit>false</Prefer32Bit>
     <PackageType>DotnetCliTool</PackageType>
     <PackageId>NBench.Runner.DotNetCli</PackageId>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>

--- a/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
+++ b/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
@@ -3,15 +3,14 @@
   <PropertyGroup>
     <Description>Cross-platform performance benchmarking and testing framework for .NET applications.</Description>
     <Copyright>Copyright (c) Petabridge https://petabridge.com/</Copyright>
-    <AssemblyTitle>NBench</AssemblyTitle>
     <VersionPrefix>0.3.4</VersionPrefix>
+    <AssemblyTitle>NBench</AssemblyTitle>
     <Authors>Petabridge</Authors>
-    <AssemblyTitle>dotnet-nbench</AssemblyTitle>
+    <AssemblyName>dotnet-nbench</AssemblyName>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <PackageType>DotnetCliTool</PackageType>
-    <AssemblyName>NBench.Runner.DotNetCli</AssemblyName>
     <PackageId>NBench.Runner.DotNetCli</PackageId>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>
     <PackageIconUrl>https://github.com/petabridge/NBench/raw/dev/images/NBench_logo_square_140.png</PackageIconUrl>

--- a/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
+++ b/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
@@ -8,7 +8,7 @@
     <Authors>Petabridge</Authors>
     <AssemblyName>dotnet-nbench</AssemblyName>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <PackageType>DotnetCliTool</PackageType>
     <PackageId>NBench.Runner.DotNetCli</PackageId>

--- a/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
+++ b/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <Description>Cross-platform performance benchmarking and testing framework for .NET applications.</Description>
     <Copyright>Copyright (c) Petabridge https://petabridge.com/</Copyright>
-    <VersionPrefix>0.3.4</VersionPrefix>
     <AssemblyTitle>NBench</AssemblyTitle>
-    <Authors>Petabridge</Authors>
     <AssemblyName>dotnet-nbench</AssemblyName>
+    <VersionPrefix>0.3.4</VersionPrefix>
+    <Authors>Petabridge</Authors>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
-    <RuntimeIdentifiers>win7-x64;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>win7-x64;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <Prefer32Bit>false</Prefer32Bit>
     <PackageType>DotnetCliTool</PackageType>
     <PackageId>NBench.Runner.DotNetCli</PackageId>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>

--- a/src/NBench.Runner/NBench.Runner.csproj
+++ b/src/NBench.Runner/NBench.Runner.csproj
@@ -10,7 +10,6 @@
     <TargetFramework>net452</TargetFramework>
     <OutputType>Exe</OutputType>   
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <Prefer32Bit>false</Prefer32Bit>
     <PackageId>NBench.Runner</PackageId>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>
     <PackageIconUrl>https://github.com/petabridge/NBench/raw/dev/images/NBench_logo_square_140.png</PackageIconUrl>

--- a/src/NBench.Runner/NBench.Runner.csproj
+++ b/src/NBench.Runner/NBench.Runner.csproj
@@ -4,12 +4,13 @@
     <Description>Cross-platform performance benchmarking and testing framework for .NET applications.</Description>
     <Copyright>Copyright (c) Petabridge https://petabridge.com/</Copyright>
     <AssemblyTitle>NBench</AssemblyTitle>
+    <AssemblyName>NBench.Runner</AssemblyName>
     <VersionPrefix>0.3.4</VersionPrefix>
     <Authors>Petabridge</Authors>
     <TargetFramework>net452</TargetFramework>
     <OutputType>Exe</OutputType>   
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <AssemblyName>NBench.Runner</AssemblyName>
+    <Prefer32Bit>false</Prefer32Bit>
     <PackageId>NBench.Runner</PackageId>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>
     <PackageIconUrl>https://github.com/petabridge/NBench/raw/dev/images/NBench_logo_square_140.png</PackageIconUrl>


### PR DESCRIPTION
This fully enables the pulling of the `NBench.Runner.DotNetCli` tool down from NuGet into a project to be called via command line with `dotnet nbench` rather than `dotnet run NBench.Runner.DotNetCli.dll` per issue #165.