### PR TITLE
v1.0.0 Release (Revision to address CI/NuGet issue)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -284,20 +284,26 @@ Target "PublishNuget" (fun _ ->
 
     if (shouldPushSymbolsPackages) then
         let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --source %s --api-key %s --symbol-source %s --symbol-api-key %s" project source apiKey symbolSource symbolsApiKey)
+            try
+                DotNetCli.RunCommand
+                    (fun p -> 
+                        { p with 
+                            TimeOut = TimeSpan.FromMinutes 10. })
+                    (sprintf "nuget push %s --source %s --api-key %s --symbol-source %s --symbol-api-key %s" project source apiKey symbolSource symbolsApiKey)
+            with exn ->
+                logfn "%s" exn.Message
 
         symbols |> Seq.iter (runSingleProject)
     else
         let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --api-key %s --source %s" project apiKey source)
+            try
+                DotNetCli.RunCommand
+                    (fun p -> 
+                        { p with 
+                            TimeOut = TimeSpan.FromMinutes 10. })
+                    (sprintf "nuget push %s --api-key %s --source %s" project apiKey source)
+            with exn ->
+                logfn "%s" exn.Message
 
         projects |> Seq.iter (runSingleProject)
 )


### PR DESCRIPTION
Official NBench 1.0.0 release PR failed the `dotnet nuget push` step on the first merge.  This PR sets up build.fsx to swallow exceptions so not to skip any following `nuget push` if a single one fails.