### PR TITLE
Update to target netcoreapp1.1 runtime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,9 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# behavior for bash scripts
+# bash scripts must keep Unix line endings
+###############################################################################
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ build/
 .nuget/
 .dotnet/
 .idea/.idea.NBench.NetCore/.idea/*
+launchSettings.json

--- a/build.fsx
+++ b/build.fsx
@@ -96,7 +96,7 @@ Target "Build" (fun _ ->
                 (fun p ->
                     { p with
                         Project = project
-                        Framework = "netcoreapp1.0"
+                        Framework = "netcoreapp1.1"
                         Configuration = configuration })
 
         let netCoreProjects = (!! "./src/**/*NBench.Runner.DotNetCli.csproj"
@@ -127,7 +127,7 @@ Target "RunTests" (fun _ ->
                 (fun p -> 
                     { p with
                         Project = project
-                        Framework = "netcoreapp1.0"
+                        Framework = "netcoreapp1.1"
                         Configuration = configuration})
 
         let projects = (!! "./tests/**/*NBench.Tests*.csproj" 
@@ -174,10 +174,10 @@ Target "NBench" <| fun _ ->
                     Project = netCoreNbenchRunnerProject
                     Configuration = configuration 
                     Runtime = "win7-x64"
-                    Framework = "netcoreapp1.0"})   
+                    Framework = "netcoreapp1.1"})   
 
-        let netCoreNbenchRunner = findToolInSubPath "dotnet-nbench.exe" "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/win7-x64/"
-        let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
+        let netCoreNbenchRunner = findToolInSubPath "dotnet-nbench.exe" "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.1/win7-x64/"
+        let netCoreAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.1/NBench.Tests.Performance.dll"
         
         let netCoreNbenchRunnerArgs = new StringBuilder()
                                         |> append netCoreAssembly
@@ -206,10 +206,10 @@ Target "NBench" <| fun _ ->
                     Project = netCoreNbenchRunnerProject
                     Configuration = configuration 
                     Runtime = "debian.8-x64"
-                    Framework = "netcoreapp1.0"})   
+                    Framework = "netcoreapp1.1"})   
         
-        let linuxNbenchRunner =  __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/debian.8-x64/dotnet-nbench"
-        let linuxPerfAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.0/NBench.Tests.Performance.dll"
+        let linuxNbenchRunner =  __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.1/debian.8-x64/dotnet-nbench"
+        let linuxPerfAssembly = __SOURCE_DIRECTORY__ @@ "/tests/NBench.Tests.Performance/bin/Release/netcoreapp1.1/NBench.Tests.Performance.dll"
         
         let linuxNbenchRunnerArgs = new StringBuilder()
                                         |> append linuxPerfAssembly
@@ -220,7 +220,7 @@ Target "NBench" <| fun _ ->
 
         let result = ExecProcess(fun info -> 
             info.FileName <- linuxNbenchRunner
-            info.WorkingDirectory <- __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.0/debian.8-x64/"
+            info.WorkingDirectory <- __SOURCE_DIRECTORY__ @@ "/src/NBench.Runner.DotNetCli/bin/Release/netcoreapp1.1/debian.8-x64/"
             info.Arguments <- linuxNbenchRunnerArgs) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" linuxNbenchRunner linuxNbenchRunnerArgs
 
@@ -245,7 +245,7 @@ Target "CopyOutput" (fun _ ->
         projects |> List.iter (fun p -> publishSingleProjectNet45 p)
     
     let netCoreProjects = [ ("NBench", "./src/NBench/NBench.csproj", "netstandard1.6");
-                            ("NBench.Runner.DotNetCli", "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj", "netcoreapp1.0") ]
+                            ("NBench.Runner.DotNetCli", "./src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj", "netcoreapp1.1") ]
 
     let publishSingleProjectNetCoreApp project = 
         let projectName, projectPath, projectFramework = project

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0";
+$DotNetVersion = "1.0.3";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 1.0.0 --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 1.0.3 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
+++ b/src/NBench.Runner.DotNetCli/NBench.Runner.DotNetCli.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>dotnet-nbench</AssemblyName>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Petabridge</Authors>
-    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <PackageType>DotnetCliTool</PackageType>

--- a/tests/NBench.Tests.Assembly/NBench.Tests.Assembly.csproj
+++ b/tests/NBench.Tests.Assembly/NBench.Tests.Assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\..\src\NBench\NBench.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.0" />
   </ItemGroup>
@@ -27,7 +27,7 @@
     <DefineConstants>$(DefineConstants);THREADPOOL;APPDOMAIN;SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/tests/NBench.Tests.End2End/NBench.Tests.End2End.csproj
+++ b/tests/NBench.Tests.End2End/NBench.Tests.End2End.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.0" />
   </ItemGroup>
@@ -36,7 +36,7 @@
     <DefineConstants>$(DefineConstants);THREADPOOL;APPDOMAIN;SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
+++ b/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
@@ -100,13 +100,13 @@ namespace NBench.Tests.End2End
 		private static TestPackage LoadPackage(IEnumerable<string> include = null, IEnumerable<string> exclude = null)
 		{
 #if CORECLR
-		    var assemblySubfolder = "netcoreapp1.0";
+		    var assemblySubfolder = "netcoreapp1.1";
 #else
 		    var assemblySubfolder = "net452";
 #endif
 
 #if DEBUG
-	        var package = new TestPackage(".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + "NBench.Tests.Assembly" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "Debug" + Path.DirectorySeparatorChar + assemblySubfolder + Path.DirectorySeparatorChar + "NBench.Tests.Assembly.dll", include, exclude);
+	        var package = new TestPackage(".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + "NBench.Tests.Assembly" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "Release" + Path.DirectorySeparatorChar + assemblySubfolder + Path.DirectorySeparatorChar + "NBench.Tests.Assembly.dll", include, exclude);
 #else
             var package = new TestPackage(".." + Path.DirectorySeparatorChar + ".."+ Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar + "NBench.Tests.Assembly" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "Release" + Path.DirectorySeparatorChar + assemblySubfolder + Path.DirectorySeparatorChar + "NBench.Tests.Assembly.dll", include, exclude);
 #endif

--- a/tests/NBench.Tests.Performance/NBench.Tests.Performance.csproj
+++ b/tests/NBench.Tests.Performance/NBench.Tests.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
     <DefineConstants>$(DefineConstants);THREADPOOL;APPDOMAIN;SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/tests/NBench.Tests/NBench.Tests.csproj
+++ b/tests/NBench.Tests/NBench.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
     <DefineConstants>$(DefineConstants);THREADPOOL;APPDOMAIN;SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Upgrade .NET Core targeting test libs to `netcoreapp1.1` for consistency with Akka.NET v1.3 branch