### PR TITLE
Reverts changes made to IDiscovery interface

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -91,7 +91,7 @@ Target "RunTests" (fun _ ->
                 { p with 
                     WorkingDir = (Directory.GetParent project).FullName
                     TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))   
+                (sprintf "xunit -parallel none -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))   
 
     let projects = 
         match (isWindows) with 

--- a/build.fsx
+++ b/build.fsx
@@ -91,7 +91,7 @@ Target "RunTests" (fun _ ->
                 { p with 
                     WorkingDir = (Directory.GetParent project).FullName
                     TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "xunit -parallel none -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))   
+                (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))   
 
     let projects = 
         match (isWindows) with 

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -48,7 +48,7 @@ namespace NBench.Sdk.Compiler
         /// </summary>
         /// <param name="assemblyPath">The path to an assembly</param>
         /// <returns>The assembly at the specified location</returns>
-        public static Assembly[] LoadAssembly(string assemblyPath)
+        public static Assembly LoadAssembly(string assemblyPath)
         {
 #if CORECLR
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) => DefaultOnResolving(assemblyLoadContext, assemblyName, assemblyPath);
@@ -64,7 +64,7 @@ namespace NBench.Sdk.Compiler
                     .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)))));
             assemblies.AddRange(targetAssembly.GetReferencedAssemblies()
                 .Select(r => AssemblyLoadContext.Default.LoadFromAssemblyName(r)));
-            return assemblies.ToArray();
+            return targetAssembly;
 #else
             AppDomain currentDomain = AppDomain.CurrentDomain;
             currentDomain.AssemblyResolve += ((sender, e) => ResolveAssembly(sender, e, assemblyPath));
@@ -75,7 +75,7 @@ namespace NBench.Sdk.Compiler
             {
                 assemblies.Add(Assembly.Load(dependency));
             }
-            return assemblies.ToArray();
+            return targetAssembly;
 #endif
         }
 

--- a/src/NBench/Sdk/Compiler/IDiscovery.cs
+++ b/src/NBench/Sdk/Compiler/IDiscovery.cs
@@ -30,7 +30,7 @@ namespace NBench.Sdk.Compiler
         /// </summary>
         /// <param name="targetAssembly">The assembly we're going to scan for benchmarks.</param>
         /// <returns>A list of <see cref="Benchmark"/>s we can run based on the classes found inside <paramref name="targetAssembly"/>.</returns>
-        IEnumerable<Benchmark> FindBenchmarks(Assembly[] targetAssembly);
+        IEnumerable<Benchmark> FindBenchmarks(Assembly targetAssembly);
 
         /// <summary>
         /// Uses reflection on the target assembly to discover <see cref="PerfBenchmarkAttribute"/>

--- a/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
+++ b/src/NBench/Sdk/Compiler/ReflectionDiscovery.cs
@@ -54,7 +54,7 @@ namespace NBench.Sdk.Compiler
         public RunnerSettings RunnerSettings { get; }
         public IBenchmarkTrace Trace { get; }
 
-        public IEnumerable<Benchmark> FindBenchmarks(Assembly[] targetAssembly)
+        public IEnumerable<Benchmark> FindBenchmarks(Assembly targetAssembly)
         {
             var benchmarkMetaData = ClassesWithPerformanceBenchmarks(targetAssembly).SelectMany(CreateBenchmarksForClass).ToList();
             var benchmarks = new List<Benchmark>(benchmarkMetaData.Count());
@@ -136,13 +136,13 @@ namespace NBench.Sdk.Compiler
         ///     A list of all applicable types that contain at least one method with a
         ///     <see cref="PerfBenchmarkAttribute" />.
         /// </returns>
-        public static IReadOnlyList<TypeInfo> ClassesWithPerformanceBenchmarks(Assembly[] targetAssembly)
+        public static IReadOnlyList<TypeInfo> ClassesWithPerformanceBenchmarks(Assembly targetAssembly)
         {
             Contract.Requires(targetAssembly != null);
             
-            return targetAssembly.SelectMany(y => y.DefinedTypes.Where(
+            return targetAssembly.DefinedTypes.Where(
                 x =>
-                    x.GetMethods().Any(MethodHasValidBenchmark) && !x.IsAbstract && x.IsClass).ToList()).ToList();
+                    x.GetMethods().Any(MethodHasValidBenchmark) && !x.IsAbstract && x.IsClass).ToList();
         }
 
         public static IReadOnlyList<BenchmarkClassMetadata> CreateBenchmarksForClass(Type classWithBenchmarks)

--- a/tests/NBench.PerformanceCounters.Tests.End2End/PerformanceCounterIntegrationTests.cs
+++ b/tests/NBench.PerformanceCounters.Tests.End2End/PerformanceCounterIntegrationTests.cs
@@ -25,7 +25,7 @@ namespace NBench.PerformanceCounters.Tests.End2End
         [Fact]
         public void ShouldPassAllBenchmarks()
         {
-            var benchmarks = _discovery.FindBenchmarks(new[] { GetType().Assembly }).ToList();
+            var benchmarks = _discovery.FindBenchmarks(GetType().Assembly).ToList();
             Assert.True(benchmarks.Count >= 1);
             Benchmark.PrepareForRun(); // force some GC here
             for (var i = 0; i < benchmarks.Count; i++)

--- a/tests/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
+++ b/tests/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
@@ -38,7 +38,7 @@ namespace NBench.Tests.End2End
         {
             if (!TestRunner.IsMono) // this spec currently hits a runtime exception with Mono: https://bugzilla.xamarin.com/show_bug.cgi?id=43291
             {
-                var benchmarks = _discovery.FindBenchmarks(new [] { GetType().GetTypeInfo().Assembly }).ToList();
+                var benchmarks = _discovery.FindBenchmarks(GetType().GetTypeInfo().Assembly).ToList();
                 Assert.True(benchmarks.Count >= 1);
                 Benchmark.PrepareForRun(); // force some GC here
                 for (var i = 0; i < benchmarks.Count; i++)

--- a/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
+++ b/tests/NBench.Tests.End2End/NBenchIntregrationTest.cs
@@ -30,7 +30,7 @@ namespace NBench.Tests.End2End
         {
             if (!TestRunner.IsMono) // this spec currently hits a runtime exception with Mono: https://bugzilla.xamarin.com/show_bug.cgi?id=43291
             {
-                var benchmarks = _discovery.FindBenchmarks(new[] { GetType().GetTypeInfo().Assembly }).ToList();
+                var benchmarks = _discovery.FindBenchmarks(GetType().GetTypeInfo().Assembly).ToList();
                 Assert.True(benchmarks.Count >= 1);
                 Benchmark.PrepareForRun(); // force some GC here
                 for (var i = 0; i < benchmarks.Count; i++)


### PR DESCRIPTION
#193 introduced a change to the IDiscovery.FindBenchmarks signature.  This reverts that change as it was (likely) not necessary.  Ran tests locally but CI to validate.