### PR TITLE
Enforce rebuilding of project in build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -77,7 +77,8 @@ Target "Build" (fun _ ->
             (fun p -> 
                 { p with
                     Project = project
-                    Configuration = configuration })   
+                    Configuration = configuration 
+                    AdditionalArgs = ["--no-incremental"]}) // "Rebuild"  
 
     let projects = !! "./src/**/*.csproj" ++ "./tests/**/*.csproj"
      

--- a/build.fsx
+++ b/build.fsx
@@ -86,6 +86,18 @@ Target "Build" (fun _ ->
 )
 
 Target "RunTests" (fun _ ->
+    let sampleBenchmarProjects = !! "./tests/**/NBench.Tests.Performance.csproj"
+                                 ++ "./tests/**/NBench.Tests.Performance.WithDependencies.csproj"
+                                 ++ "./tests/**/NBench.Tests.Assembly.csproj"
+    
+    sampleBenchmarProjects |> Seq.iter (fun proj ->
+        DotNetCli.Build
+            (fun p ->
+                { p with
+                    Project = proj
+                    Configuration = configuration
+                    AdditionalArgs = ["--no-incremental"]}))
+
     let runSingleProject project =
         DotNetCli.RunCommand
             (fun p -> 

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -53,15 +53,15 @@ namespace NBench.Sdk.Compiler
 #if CORECLR
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) => DefaultOnResolving(assemblyLoadContext, assemblyName, assemblyPath);
             var targetAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            //var dependencies = DependencyContext.Load(targetAssembly)
-            //    .CompileLibraries
-            //    .Where(dep => dep.Name.ToLower()
-            //        .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
-            //    .ToList();
+            DependencyContext.Load(targetAssembly)
+                .CompileLibraries
+                .Where(dep => dep.Name.ToLower()
+                    .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
+                .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)));
             //var assemblies = new List<Assembly> { targetAssembly };
             //assemblies.AddRange(dependencies
             //    .SelectMany(d => d.Dependencies
-            //        .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)))));
+            //        
             //assemblies.AddRange(targetAssembly.GetReferencedAssemblies()
             //    .Select(r => AssemblyLoadContext.Default.LoadFromAssemblyName(r)));
             return targetAssembly;
@@ -82,7 +82,6 @@ namespace NBench.Sdk.Compiler
 #if !CORECLR
         private static Assembly ResolveAssembly(object sender, ResolveEventArgs e, string assemblyPath)
         {
-            //The name would contain versioning and other information. Let's say you want to load by name.
             string dllName = e.Name.Split(new[] { ',' })[0] + ".dll";
             return Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(assemblyPath), dllName));
         }

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -53,22 +53,16 @@ namespace NBench.Sdk.Compiler
 #if CORECLR
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) => DefaultOnResolving(assemblyLoadContext, assemblyName, assemblyPath);
             var targetAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            //DependencyContext.Load(targetAssembly)
-            //    .CompileLibraries
-            //    .Where(dep => dep.Name.ToLower()
-            //        .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
-            //    .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)));
+            DependencyContext.Load(targetAssembly)
+                .CompileLibraries
+                .Where(dep => dep.Name.ToLower()
+                    .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
+                .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)));
             return targetAssembly;
 #else
             AppDomain currentDomain = AppDomain.CurrentDomain;
             currentDomain.AssemblyResolve += ((sender, e) => ResolveAssembly(sender, e, assemblyPath));
             var targetAssembly = Assembly.LoadFrom(assemblyPath);
-            var assemblies = new List<Assembly>();
-            assemblies.Add(targetAssembly);
-            foreach (var dependency in targetAssembly.GetReferencedAssemblies())
-            {
-                assemblies.Add(Assembly.Load(dependency));
-            }
             return targetAssembly;
 #endif
         }

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -90,6 +90,7 @@ namespace NBench.Sdk.Compiler
         private static Assembly DefaultOnResolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName, string assemblyPath)
         {
             string dllName = assemblyName.Name.Split(new[] { ',' })[0] + ".dll";
+            Console.WriteLine($"Searching for {dllName} in folder {Path.Combine(Path.GetDirectoryName(assemblyPath))}");
             return assemblyLoadContext.LoadFromAssemblyPath(Path.Combine(Path.GetDirectoryName(assemblyPath), dllName));
         }
 #endif

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -53,17 +53,11 @@ namespace NBench.Sdk.Compiler
 #if CORECLR
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) => DefaultOnResolving(assemblyLoadContext, assemblyName, assemblyPath);
             var targetAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            DependencyContext.Load(targetAssembly)
-                .CompileLibraries
-                .Where(dep => dep.Name.ToLower()
-                    .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
-                .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)));
-            //var assemblies = new List<Assembly> { targetAssembly };
-            //assemblies.AddRange(dependencies
-            //    .SelectMany(d => d.Dependencies
-            //        
-            //assemblies.AddRange(targetAssembly.GetReferencedAssemblies()
-            //    .Select(r => AssemblyLoadContext.Default.LoadFromAssemblyName(r)));
+            //DependencyContext.Load(targetAssembly)
+            //    .CompileLibraries
+            //    .Where(dep => dep.Name.ToLower()
+            //        .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
+            //    .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)));
             return targetAssembly;
 #else
             AppDomain currentDomain = AppDomain.CurrentDomain;

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -90,7 +90,7 @@ namespace NBench.Sdk.Compiler
         private static Assembly DefaultOnResolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName, string assemblyPath)
         {
             string dllName = assemblyName.Name.Split(new[] { ',' })[0] + ".dll";
-            Console.WriteLine($"Searching for {dllName} in folder {Path.Combine(Path.GetDirectoryName(assemblyPath))}");
+            //Console.WriteLine($"Searching for {dllName} in folder {Path.Combine(Path.GetDirectoryName(assemblyPath))}");
             return assemblyLoadContext.LoadFromAssemblyPath(Path.Combine(Path.GetDirectoryName(assemblyPath), dllName));
         }
 #endif

--- a/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/AssemblyRuntimeLoader.cs
@@ -53,17 +53,17 @@ namespace NBench.Sdk.Compiler
 #if CORECLR
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) => DefaultOnResolving(assemblyLoadContext, assemblyName, assemblyPath);
             var targetAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            var dependencies = DependencyContext.Load(targetAssembly)
-                .CompileLibraries
-                .Where(dep => dep.Name.ToLower()
-                    .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
-                .ToList();
-            var assemblies = new List<Assembly> { targetAssembly };
-            assemblies.AddRange(dependencies
-                .SelectMany(d => d.Dependencies
-                    .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)))));
-            assemblies.AddRange(targetAssembly.GetReferencedAssemblies()
-                .Select(r => AssemblyLoadContext.Default.LoadFromAssemblyName(r)));
+            //var dependencies = DependencyContext.Load(targetAssembly)
+            //    .CompileLibraries
+            //    .Where(dep => dep.Name.ToLower()
+            //        .Contains(targetAssembly.FullName.Split(new[] { ',' })[0].ToLower()))
+            //    .ToList();
+            //var assemblies = new List<Assembly> { targetAssembly };
+            //assemblies.AddRange(dependencies
+            //    .SelectMany(d => d.Dependencies
+            //        .Select(dependency => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(dependency.Name)))));
+            //assemblies.AddRange(targetAssembly.GetReferencedAssemblies()
+            //    .Select(r => AssemblyLoadContext.Default.LoadFromAssemblyName(r)));
             return targetAssembly;
 #else
             AppDomain currentDomain = AppDomain.CurrentDomain;
@@ -90,7 +90,6 @@ namespace NBench.Sdk.Compiler
         private static Assembly DefaultOnResolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName, string assemblyPath)
         {
             string dllName = assemblyName.Name.Split(new[] { ',' })[0] + ".dll";
-            //Console.WriteLine($"Searching for {dllName} in folder {Path.Combine(Path.GetDirectoryName(assemblyPath))}");
             return assemblyLoadContext.LoadFromAssemblyPath(Path.Combine(Path.GetDirectoryName(assemblyPath), dllName));
         }
 #endif

--- a/tests/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
+++ b/tests/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace NBench.Tests.End2End
 {
-    public class NBenchIntregrationTestWithDependencies
+    public class NBenchIntregrationTestWithDependencies : IDisposable
     {
         private static readonly IBenchmarkOutput _benchmarkOutput = new ActionBenchmarkOutput(report => { }, results =>
         {
@@ -24,7 +24,7 @@ namespace NBench.Tests.End2End
             }
         });
 
-        private readonly IDiscovery _discovery = new ReflectionDiscovery(_benchmarkOutput);
+        private IDiscovery _discovery = new ReflectionDiscovery(_benchmarkOutput);
 
         private readonly ITestOutputHelper _output;
 
@@ -76,6 +76,14 @@ namespace NBench.Tests.End2End
 
             package.Validate();
             return package;
+        }
+
+        public void Dispose()
+        {
+            if (_discovery != null)
+            {
+                _discovery = null;
+            }
         }
     }
 }

--- a/tests/NBench.Tests.Performance.WithDependencies/NBench.Tests.Performance.WithDependencies.csproj
+++ b/tests/NBench.Tests.Performance.WithDependencies/NBench.Tests.Performance.WithDependencies.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Tests.Performance</AssemblyTitle>
-    <TargetFrameworks>net452; netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 


### PR DESCRIPTION
An attempt to fix intermittent integration test failures for the tests added to validate that assemblies with dependencies are loaded into the runner.  Adds flag `--no-incremental` which is synonymous with "Rebuild".