### PR TITLE
update downstream NuGet dependencies

### DIFF
--- a/src/NBench/NBench.csproj
+++ b/src/NBench/NBench.csproj
@@ -24,13 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.Contracts" Version="4.0.1" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.0" />
+    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NBench/Sdk/Compiler/Assemblies/NetCoreAssemblyRuntimeLoader.cs
+++ b/src/NBench/Sdk/Compiler/Assemblies/NetCoreAssemblyRuntimeLoader.cs
@@ -39,7 +39,6 @@ namespace NBench.Sdk.Compiler.Assemblies
             _resolver = new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]{
                 new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(Assembly.CodeBase)),
                 new ReferenceAssemblyPathResolver(),
-                new PackageCacheCompilationAssemblyResolver(),
                 new PackageCompilationAssemblyResolver()});
 
             _loadContext.Resolving += LoadContextOnResolving;
@@ -66,7 +65,6 @@ namespace NBench.Sdk.Compiler.Assemblies
             _resolver = new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]{
                 new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
                 new ReferenceAssemblyPathResolver(),
-                new PackageCacheCompilationAssemblyResolver(),
                 new PackageCompilationAssemblyResolver()});
 
             _loadContext.Resolving += LoadContextOnResolving;

--- a/src/common.props
+++ b/src/common.props
@@ -11,7 +11,7 @@
       https://github.com/petabridge/NBench/blob/dev/LICENSE
     </PackageLicenseUrl>
     <PackageTags>performance;benchmarking;benchmark;perf;testing;NBench</PackageTags>
-    <NoWarn>$(NoWarn);CS1591;NU1605</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;</NoWarn>
     <PackageIconUrl>https://github.com/petabridge/NBench/raw/dev/images/NBench_logo_square_140.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/petabridge/NBench</RepositoryUrl>


### PR DESCRIPTION
close #246 - also disabled `NoWarn` for NU1605 inside the solution so we can catch these issues on-build in the future.