### PR TITLE
disabled .NET Core 2.0 integration tests

### DIFF
--- a/tests/NBench.Tests.Performance/NBench.Tests.Performance.csproj
+++ b/tests/NBench.Tests.Performance/NBench.Tests.Performance.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\src\common.props" />
   <Import Project="..\..\src\NBench\build\NBench.targets" />
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
until we can update build-server images to support multiple runtimes of .NET Core, I think it best that we disable these so we can get our green checkmark back.