### PR TITLE
added v1.2.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### v1.2.2 July 24 2018
+* [Bug: unable to propagate --concurrent setting to .NET Core executables via dotnet nbench](https://github.com/petabridge/NBench/issues/250) - fixed.
+* [.Net Core: NU1605    Detected package downgrade: System.Reflection.TypeExtensions](https://github.com/petabridge/NBench/issues/246) - fixed.
+
 #### v1.2.1 July 11 2018
 Fixed an issue with the `dotnet-nbench` package where it missed a required runtime in order to execute against .NET Core 2.* projects. 
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.2.1</VersionPrefix>
-    <PackageReleaseNotes>Fixed an issue with the `dotnet-nbench` package where it missed a required runtime in order to execute against .NET Core 2.* projects.</PackageReleaseNotes>
+    <VersionPrefix>1.2.2</VersionPrefix>
+    <PackageReleaseNotes>[Bug: unable to propagate --concurrent setting to .NET Core executables via dotnet nbench](https://github.com/petabridge/NBench/issues/250) - fixed.
+[.Net Core: NU1605    Detected package downgrade: System.Reflection.TypeExtensions](https://github.com/petabridge/NBench/issues/246) - fixed.</PackageReleaseNotes>
     <PackageProjectUrl>
       https://github.com/petabridge/NBench
     </PackageProjectUrl>


### PR DESCRIPTION
#### v1.2.2 July 24 2018
* [Bug: unable to propagate --concurrent setting to .NET Core executables via dotnet nbench](https://github.com/petabridge/NBench/issues/250) - fixed.
* [.Net Core: NU1605    Detected package downgrade: System.Reflection.TypeExtensions](https://github.com/petabridge/NBench/issues/246) - fixed.