### PR TITLE
added 2.0.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### v2.0.0 February 24 2020
+#### v2.0.1 February 25 2020
 NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:
 
 - `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
@@ -7,3 +7,13 @@ NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and th
 - NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).
 
 For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).
+
+---
+
+2.0.1 Notes:
+
+* Fixed error with setting thread priority on Linux;
+* Fixed NuGet symbol publication;
+* And more.
+
+For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).

--- a/src/common.props
+++ b/src/common.props
@@ -2,13 +2,19 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <PackageReleaseNotes>NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:
 - `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
 - NBench no longer supports .NET Framework explicitly; moving forward NBench will only support .NET Standard 2.0 and later (.NET Framework 4.6.1 and greater or .NET Core 2.0 and greater.)
 - We've added a new documentation website for NBench: https://nbench.io/
 - NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).
-For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).</PackageReleaseNotes>
+For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).
+---
+2.0.1 Notes:
+Fixed error with setting thread priority on Linux;
+Fixed NuGet symbol publication;
+And more.
+For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).</PackageReleaseNotes>
     <PackageProjectUrl>
       https://nbench.io/
     </PackageProjectUrl>
@@ -31,7 +37,7 @@ For a full set of changes, [please see the NBench 2.0.0 milestone on Github](htt
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
   </PropertyGroup>
-   <PropertyGroup>
+  <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->


### PR DESCRIPTION
#### v2.0.1 February 25 2020
NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:

- `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
- NBench no longer supports .NET Framework explicitly; moving forward NBench will only support .NET Standard 2.0 and later (.NET Framework 4.6.1 and greater or .NET Core 2.0 and greater.)
- We've added a new documentation website for NBench: https://nbench.io/
- NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).

For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).

---

2.0.1 Notes:

* Fixed error with setting thread priority on Linux;
* Fixed NuGet symbol publication;
* And more.

For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).