### PR TITLE
2.0.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Cross-platform performance benchmarking and testing framework for .NET applicati
 
 NBench is designed for .NET developers who need to care about performance and want the ability to "unit test" their application's performance just like [XUnit](https://github.com/xunit/xunit) or [NUnit](http://nunit.org/) tests their application code.
 
+## Build Status
+
+| Stage             | Status                                                                                                                                                                                                                                   |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Windows Tests     | [![Build Status](https://dev.azure.com/petabridge/NBench/_apis/build/status/NBench%20PR%20Validation?branchName=dev&jobName=Windows%20Tests)](https://dev.azure.com/petabridge/NBench/_build/latest?definitionId=115&branchName=dev)     |
+| Integration Tests | [![Build Status](https://dev.azure.com/petabridge/NBench/_apis/build/status/NBench%20PR%20Validation?branchName=dev&jobName=Integration%20Tests)](https://dev.azure.com/petabridge/NBench/_build/latest?definitionId=115&branchName=dev) |
+| NuGet Pack        | [![Build Status](https://dev.azure.com/petabridge/NBench/_apis/build/status/NBench%20PR%20Validation?branchName=dev&jobName=NuGet%20Pack)](https://dev.azure.com/petabridge/NBench/_build/latest?definitionId=115&branchName=dev)        |
+
 ## Documentation
 To learn more, please read [the official NBench documentation](https://nbench.io).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### v2.0.0 February 24 2020
+#### v2.0.1 February 25 2020
 NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:
 
 - `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
@@ -7,3 +7,13 @@ NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and th
 - NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).
 
 For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).
+
+---
+
+2.0.1 Notes:
+
+* Fixed error with setting thread priority on Linux;
+* Fixed NuGet symbol publication;
+* And more.
+
+For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -31,7 +31,16 @@ jobs:
       scriptFileName: build.cmd
       scriptArgs: NBench
       outputDirectory: 'PerfResults'
-      artifactName: 'integration_tests-$(Build.BuildId)'
+      artifactName: 'integration_tests_windows-$(Build.BuildId)'
+  - template: azure-pipeline.template.yaml
+    parameters:
+      name: 'linux_integration'
+      displayName: 'Integration Tests (Linux)'
+      vmImage: 'ubuntu-16.04'
+      scriptFileName: build.sh
+      scriptArgs: NBench
+      outputDirectory: 'PerfResults'
+      artifactName: 'integration_tests_linux-$(Build.BuildId)'
   - template: azure-pipeline.template.yaml
     parameters:
       name: 'nuget_pack'

--- a/src/NBench.TestAssembly/NBench.TestAssembly.csproj
+++ b/src/NBench.TestAssembly/NBench.TestAssembly.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
     <AssemblyName>NBench.TestAssembly</AssemblyName>
     <RootNamespace>NBench.TestAssembly</RootNamespace>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
+++ b/src/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
@@ -65,6 +65,9 @@ namespace NBench.Tests.End2End
                     package.AddExclude(e);
                 }
 
+            // need to set this to true in order to resolve https://github.com/petabridge/NBench/issues/314
+            package.Concurrent = true;
+
             return package;
         }
     }

--- a/src/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
+++ b/src/NBench.Tests.End2End/NBenchIntegrationTest.WithDependencies.cs
@@ -30,10 +30,23 @@ namespace NBench.Tests.End2End
         {
             var package = LoadPackageWithDependencies().AddOutput(_benchmarkOutput);
             var result = TestRunner.Run(package);
-            
-            result.AllTestsPassed.Should().BeTrue("Expected all tests to pass, but did not.");
-            result.ExecutedTestsCount.Should().NotBe(0);
-            result.IgnoredTestsCount.Should().Be(0);
+
+            try
+            {
+                result.AllTestsPassed.Should().BeTrue("Expected all tests to pass, but did not.");
+                result.ExecutedTestsCount.Should().NotBe(0);
+                result.IgnoredTestsCount.Should().Be(0);
+            }
+            catch
+            {
+                foreach (var test in result.FullResults)
+                {
+                    _output.WriteLine($"DEBUG: Checking output for {test.BenchmarkName}");
+                    foreach(var a in test.AssertionResults)
+                        _output.WriteLine($"ASSERT: {a.MetricName} - Passed? {a.Passed}");
+                }
+                throw;
+            }
         }
 
         private static TestPackage LoadPackageWithDependencies(IEnumerable<string> include = null, IEnumerable<string> exclude = null)

--- a/src/NBench/Sdk/Benchmark.cs
+++ b/src/NBench/Sdk/Benchmark.cs
@@ -43,7 +43,7 @@ namespace NBench.Sdk
         /// <param name="invoker">The invoker used to execute benchmark and setup / cleanup methods.</param>
         /// <param name="writer">The output target this benchmark will write to.</param>
         /// <remarks>Uses the <see cref="DefaultBenchmarkAssertionRunner"/> to assert benchmark data.</remarks>
-        public Benchmark(BenchmarkSettings settings, IBenchmarkInvoker invoker, IBenchmarkOutput writer) 
+        public Benchmark(BenchmarkSettings settings, IBenchmarkInvoker invoker, IBenchmarkOutput writer)
             : this(settings, invoker, writer, DefaultBenchmarkAssertionRunner.Instance) { }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace NBench.Sdk
             var runTime = 0L;
 
             /* Pre-Warmup */
-           
+
 
             Trace.Debug("----- BEGIN PRE-WARMUP -----");
             /* Estimate */
@@ -128,7 +128,7 @@ namespace NBench.Sdk
                         {
                             runEstimates[i - 1] = runCount;
                             timeEstimates[i - 1] = warmupStopWatch.ElapsedTicks;
-                            
+
                         }
 
                         runCount = 0;
@@ -136,8 +136,8 @@ namespace NBench.Sdk
                     }
 
                     runCount = (long)Math.Ceiling(runEstimates.Average());
-                    runTime = (long) Math.Ceiling(timeEstimates.Average());
-                       
+                    runTime = (long)Math.Ceiling(timeEstimates.Average());
+
                     Trace.Debug(
                         $"Throughput mode: executed {runCount} instances of {BenchmarkName} in roughly {targetTime.TotalSeconds}s. Using that figure for benchmark.");
                 }
@@ -225,7 +225,7 @@ namespace NBench.Sdk
             {
                 Output.Warning($"Error during previous run of {BenchmarkName}. Aborting run...");
             }
-            
+
         }
 
         public void Shutdown()
@@ -262,12 +262,12 @@ namespace NBench.Sdk
                     // the invoker with an inlined loop
                     Invoker.InvokePerfSetup(WarmupData.EstimatedRunsPerSecond, _currentRun.Context);
                 }
-                    else
+                else
                 {
                     // Invoke user-defined setup method, if any
                     Invoker.InvokePerfSetup(_currentRun.Context);
                 }
-                
+
 
                 PrepareForRun();
             }
@@ -344,7 +344,7 @@ namespace NBench.Sdk
             _currentRun.Dispose();
             Trace.Info($"Generating report for {PrintWarmupOrRun(_isWarmup)} {1 + Settings.NumberOfIterations - _pendingIterations} of {BenchmarkName}");
             var report = _currentRun.ToReport(StopWatch.Elapsed);
-            if(!isEstimate)
+            if (!isEstimate)
                 Output.WriteRun(report, _isWarmup);
 
             // Change runs, but not on warmup

--- a/src/NBench/Sdk/TestRunner.cs
+++ b/src/NBench/Sdk/TestRunner.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 using System.Threading;
 using IBenchmarkOutput = NBench.Reporting.IBenchmarkOutput;
 
@@ -81,7 +82,7 @@ namespace NBench.Sdk
             /*
              * Set priority
              */
-            if (!IsMono)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsMono)
                 Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
             if (!concurrent)
             {

--- a/src/common.props
+++ b/src/common.props
@@ -2,13 +2,19 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <PackageReleaseNotes>NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:
 - `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
 - NBench no longer supports .NET Framework explicitly; moving forward NBench will only support .NET Standard 2.0 and later (.NET Framework 4.6.1 and greater or .NET Core 2.0 and greater.)
 - We've added a new documentation website for NBench: https://nbench.io/
 - NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).
-For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).</PackageReleaseNotes>
+For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).
+---
+2.0.1 Notes:
+Fixed error with setting thread priority on Linux;
+Fixed NuGet symbol publication;
+And more.
+For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).</PackageReleaseNotes>
     <PackageProjectUrl>
       https://nbench.io/
     </PackageProjectUrl>
@@ -31,7 +37,7 @@ For a full set of changes, [please see the NBench 2.0.0 milestone on Github](htt
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
   </PropertyGroup>
-   <PropertyGroup>
+  <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->

--- a/src/common.props
+++ b/src/common.props
@@ -22,7 +22,7 @@ For a full set of changes, [please see the NBench 2.0.0 milestone on Github](htt
     <RepositoryUrl>https://github.com/petabridge/NBench</RepositoryUrl>
   </PropertyGroup>
   <PropertyGroup>
-    <ApprovalTestsVersion>4.5.0</ApprovalTestsVersion>
+    <ApprovalTestsVersion>4.5.1</ApprovalTestsVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.5.0</TestSdkVersion>
     <FluentAssertionsVersion>5.10.2</FluentAssertionsVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -31,4 +31,16 @@ For a full set of changes, [please see the NBench 2.0.0 milestone on Github](htt
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
   </PropertyGroup>
+   <PropertyGroup>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
#### v2.0.1 February 25 2020
NBench 2.0.0 is a major departure from NBench 1.2 and preceding versions, and these changes were done in order to support NBench's future as a cutting-edge, cross-platform performance testing and macro benchmarking framework:

- `dotnet nbench` and `NBench.Runner` are both now deprecated - [NBench is now run from directly inside a console application created by end-users](https://nbench.io/articles/quickstart.html). This makes it easier to configure, debug, and create benchmarks on new .NET Core platforms without having to wait for additional instrumentation or tooling from NBench itself.
- NBench no longer supports .NET Framework explicitly; moving forward NBench will only support .NET Standard 2.0 and later (.NET Framework 4.6.1 and greater or .NET Core 2.0 and greater.)
- We've added a new documentation website for NBench: https://nbench.io/
- NBench now supports configuration as code through the [`TestPackage` class](https://nbench.io/api/NBench.Sdk.TestPackage.html).

For a full set of changes, [please see the NBench 2.0.0 milestone on Github](https://github.com/petabridge/NBench/milestone/3).

---

2.0.1 Notes:

* Fixed error with setting thread priority on Linux;
* Fixed NuGet symbol publication;
* And more.

For a full set of changes, [please see the NBench 2.0.1 milestone on Github](https://github.com/petabridge/NBench/milestone/8).